### PR TITLE
Registry cache is utilized instead of gha

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -53,6 +53,16 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.gcp_project }}
+          service_account_key: ${{ secrets.GH_ACTIONS_SERVICE_ACCOUNT }}
+          export_default_credentials: true
+
+      - name: Google Cloud Artifacts/Authorize Docker push
+        run: gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY_HOST }}
+
       - name: Build image
         id: docker_build
         uses: docker/build-push-action@v2
@@ -62,8 +72,8 @@ jobs:
           file: docker/microservice-api-multi.dockerfile/Dockerfile
           tags: ${{ env.DH_DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG}}, ${{ env.GCP_DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG}}
           outputs: type=docker,dest=image.tar
-          cache-from: type=gha,scope=${{ matrix.dotnet }}
-          cache-to: type=gha,scope=${{ matrix.dotnet }},mode=max
+          cache-from: type=registry,ref=${{ env.GCP_DOCKER_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.GCP_DOCKER_IMAGE }}:buildcache,mode=max
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
because of https://github.com/moby/buildkit/issues/2426