### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,10 +29,10 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10 SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -55,9 +55,9 @@ jobs:
         run: reportgenerator -reports:./coverage.xml -targetdir:coverage -reporttypes:Cobertura
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
-          file: ./coverage/Cobertura.xml
+          files: ./coverage/Cobertura.xml
           fail_ci_if_error: true # Set to 'false' if you want to allow CI to pass even if Codecov upload fails
 
   build:
@@ -65,27 +65,27 @@ jobs:
     #needs: test-netcore
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Set current_datetime
         id: set_datetime
         run: echo "::set-output name=current_datetime::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Google Auth
         id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GH_ACTIONS_SERVICE_ACCOUNT }}'
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build image
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.GCP_DOCKER_IMAGE }}:buildcache,mode=max
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: docker-artifact
           path: image.tar
@@ -122,14 +122,14 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
 
       - name: Load images
         run: |
           docker load --input docker-artifact/image.tar
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
     needs: [build]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
 
       - name: Load images
         run: |
@@ -151,12 +151,12 @@ jobs:
 
       - name: Google Auth
         id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GH_ACTIONS_SERVICE_ACCOUNT  }}'
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.gcp_project }}
 
@@ -178,18 +178,18 @@ jobs:
     steps:
       - name: Google Auth
         id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GH_ACTIONS_SERVICE_ACCOUNT }}'
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
 
       - name: Deploy to Cloud Run
         id: deploy
-        uses: 'google-github-actions/deploy-cloudrun@v1'
+        uses: 'google-github-actions/deploy-cloudrun@v3'
         with:
           service: ${{ env.SERVICE }}
           image: ${{ env.GCP_DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG}}
@@ -215,7 +215,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [health-googlecloud]
     steps:
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: docker-artifact
     env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Set current_datetime
         id: set_datetime
-        run: echo "::set-output name=current_datetime::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+        run: echo "current_datetime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -158,7 +158,7 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
-          project_id: ${{ secrets.gcp_project }}
+          project_id: ${{ secrets.GCP_PROJECT }}
 
       - name: Google Cloud Artifacts/Authorize Docker push
         run: gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY_HOST }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Set up .NET 10 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -36,7 +36,7 @@ jobs:
         run: ~/.dotnet/tools/docfx build docfx/docfx.json
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docfx/_site

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates into one pull request",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "groupSingleUpdates": true,
+      "separateMajorMinor": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- update every GitHub Action to its current supported major release
- migrate the Codecov input from `file` to `files` for the current action
- configure Renovate to bundle all future GitHub Actions updates into one PR

## Why

Several workflows used old Node-runtime action generations, including unsupported artifact upload/download v3 releases. Updating them restores vendor support and keeps future action maintenance consolidated.

## Validation

- `actionlint -color never .github/workflows/*.yml`
- `renovate-config-validator renovate.json`
- `make check`
- `git diff --check`