### PR TITLE
Add SonarQube development tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tools/
 healthchecksdb
 
 # Project Specific Files
+.env
 docker/postgres/data/
 
 # Coverage Test Files 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,17 @@ repos:
       - id: check-symlinks
       - id: check-yaml
       - id: forbid-submodules
+
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        entry: shellcheck
+        language: system
+        types: [shell]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.3
+    hooks:
+      - id: codespell
+        exclude: ^(files/|docfx/articles/howto/|docfx/restapi/redoc\.standalone\.js|docker/grafana/provisioning/dashboards/)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PRE_COMMIT ?= $(HOME)/.local/share/MicroService/pre-commit/bin/pre-commit
 
 .DEFAULT_GOAL := help
 
-.PHONY: help setup hooks check restore build run test
+.PHONY: help setup hooks check restore build run test sonar
 
 help:
 	@echo "Available targets:"
@@ -18,6 +18,7 @@ help:
 	@echo "  make build    Build the solution"
 	@echo "  make run      Run the Web API locally"
 	@echo "  make test     Run the test project"
+	@echo "  make sonar    Build, test, and submit analysis to SonarQube"
 	@echo ""
 	@echo "Options:"
 	@echo "  CONFIGURATION=Debug|Release (default: Debug)"
@@ -42,3 +43,6 @@ run:
 
 test:
 	$(DOTNET) test $(TEST_PROJECT) --configuration $(CONFIGURATION)
+
+sonar:
+	./scripts/sonar.sh

--- a/docfx/articles/csharp_coding_standards.md
+++ b/docfx/articles/csharp_coding_standards.md
@@ -23,7 +23,7 @@ Tools
 ----------------
 
 * [Resharper](http://www.jetbrains.com/resharper/) is a great 3rd party code cleanup and style tool.
-* [StyleCop](http://stylecop.codeplex.com/) analyzes C# srouce code to enforce a set of style and consistency rules and has been integrated into many 3rd party development tools such as Resharper.
+* [StyleCop](http://stylecop.codeplex.com/) analyzes C# source code to enforce a set of style and consistency rules and has been integrated into many 3rd party development tools such as Resharper.
 * [FxCop](http://codebox/SDLFxCop) is an application that analyzes managed code assemblies (code that targets the .NET Framework common language runtime) and reports information about the assemblies, such as possible design, localization, performance, and security improvements.
 * [C# Stylizer](http://toolbox/22561) does many of the style rules automatically
 
@@ -99,13 +99,13 @@ The class definition contains class members in the following order, from *less* 
 	2. `if (a == b)`
 
 ### Cross-platform coding
-Our code should supports multiple operating systems. Don't assume we only run (and develop) on Windows. Code should be sensitvie to the differences between OS's. Here are some specifics to consider.
+Our code should supports multiple operating systems. Don't assume we only run (and develop) on Windows. Code should be sensitive to the differences between OS's. Here are some specifics to consider.
 
-* **DO** use `Enviroment.NewLine` instead of hard-coding the line break instead of `\r\n`, as Windows uses `\r\n` and OSX/Linux uses `\n`.
+* **DO** use `Environment.NewLine` instead of hard-coding the line break instead of `\r\n`, as Windows uses `\r\n` and OSX/Linux uses `\n`.
 
 > **Note**
 > 
-> Be aware that thes line-endings may cause problems in code when using `@""` text blocks with line breaks.
+> Be aware that these line-endings may cause problems in code when using `@""` text blocks with line breaks.
 
 * **DO** Use `Path.Combine()` or `Path.DirectorySeparatorChar` to separate directories. If this is not possible (such as in scripting), use a forward slash `/`. Windows is more forgiving than Linux in this regard.
 
@@ -113,9 +113,9 @@ Our code should supports multiple operating systems. Don't assume we only run (a
 #### Assembly naming
 The unit tests for the `Microsoft.Foo` assembly live in the `Microsoft.Foo.Tests` assembly.
 
-The functional tests for the `Microsoft.Foo` assmebly live in the `Microsoft.Foo.FunctionalTests` assmebly.
+The functional tests for the `Microsoft.Foo` assembly live in the `Microsoft.Foo.FunctionalTests` assembly.
 
-In general there should be exactly one unit test assebmly for each product runtime assembly. In general there should be one functional test assembly per repo. Exceptions can be made for both.
+In general there should be exactly one unit test assembly for each product runtime assembly. In general there should be one functional test assembly per repo. Exceptions can be made for both.
 
 #### Unit test class naming
 Test class names end with `Test` and live in the same namespace as the class being tested. For example, the unit tests for the `Microsoft.Foo.Boo` class would be in a `Microsoft.Foo.Boo` class in the test assembly.
@@ -152,7 +152,7 @@ The crucial thing here is the `Act` stage is exactly one statement. That one sta
 int result = myObj.CallSomeMethod(GetComplexParam1(), GetComplexParam2(), GetComplexParam3());
 ```
 
-This style is not recomended because way too many things can go wrong in this one statement. All the `GetComplexParamN()` calls can throw for a variety of reasons unrelated to the test itself. It is thus unclear to someone running into a problem why the failure occured.
+This style is not recommended because way too many things can go wrong in this one statement. All the `GetComplexParamN()` calls can throw for a variety of reasons unrelated to the test itself. It is thus unclear to someone running into a problem why the failure occurred.
 
 The ideal pattern is to move the complex parameter building into the `Arrange section:
 

--- a/docfx/articles/csharp_coding_standards.md
+++ b/docfx/articles/csharp_coding_standards.md
@@ -99,7 +99,7 @@ The class definition contains class members in the following order, from *less* 
 	2. `if (a == b)`
 
 ### Cross-platform coding
-Our code should supports multiple operating systems. Don't assume we only run (and develop) on Windows. Code should be sensitive to the differences between OS's. Here are some specifics to consider.
+Our code should support multiple operating systems. Don't assume we only run (and develop) on Windows. Code should be sensitive to the differences between OS's. Here are some specifics to consider.
 
 * **DO** use `Environment.NewLine` instead of hard-coding the line break instead of `\r\n`, as Windows uses `\r\n` and OSX/Linux uses `\n`.
 

--- a/docfx/articles/kubernetes.md
+++ b/docfx/articles/kubernetes.md
@@ -28,7 +28,7 @@ choco install kubernetes-helm
 ![](images/docker-desktop.png)
 
 
-#### Verify Instalation 
+#### Verify Installation
 
 ```
 kubectl version
@@ -40,7 +40,7 @@ kubectl cluster-info
 kubectl get nodes
 ```
 
-### Installating the Kubernetes Dashboard
+### Installing the Kubernetes Dashboard
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml

--- a/docfx/articles/requirements.md
+++ b/docfx/articles/requirements.md
@@ -21,7 +21,7 @@ Your solution will be assessed on the following:
 * Performance
 * Code quality
 * Testing style and quality
-* Scaleability
+* Scalability
 
 Take as long as you feel is necessary to complete the task to fulfil the requirements.
 But as guidance, aim to spend no more than 3-4 hours.  

--- a/docfx/articles/sonarqube.md
+++ b/docfx/articles/sonarqube.md
@@ -9,5 +9,5 @@ SonarQube
 
 #### Prerequisites:
 ```
-Java Lattest JDK/JRE
+Java Latest JDK/JRE
 ```

--- a/docker/gdal/scripts/app.py
+++ b/docker/gdal/scripts/app.py
@@ -1,4 +1,4 @@
-# app.py - this should run automativly  when the docker is Built and Run
+# app.py - this should run automatically when the Docker image is built and run
 import os
 print ('[info] - running script in gdal container \n')
 print (r"[info] - /from_shapefile/",os.listdir(r'/scripts/from_shapefile'))
@@ -11,7 +11,7 @@ for f in os.listdir(r'/scripts/from_shapefile') :
         # the name of the json file is the same name as the shp file
         json_file = f.split('.')[0] + '.json' 
         cmd = f'ogr2ogr -f GeoJSON /scripts/to_GeoJSON/{json_file} /scripts/from_shapefile/{shp_file}'
-        print ('[info] - runing: ', cmd)
+        print ('[info] - running: ', cmd)
         os.system(cmd)
                 
 print (r"[info] - /to_GeoJSON/",os.listdir(r'/scripts/to_GeoJSON'))

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,8 +9,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="/etc/gcsfuse/key/service-account-key.json
 if [[ "${MOUNT_GCS_BUCKET}" == "true" && -n "${GCS_BUCKET_NAME}" ]]; then
     echo "Mounting GCS Bucket: ${GCS_BUCKET_NAME}"
     # Attempt to mount the GCS bucket
-    gcsfuse -o nonempty -o allow_other "${GCS_BUCKET_NAME}" /mnt/gcs-bucket
-    if [[ $? -ne 0 ]]; then
+    if ! gcsfuse -o nonempty -o allow_other "${GCS_BUCKET_NAME}" /mnt/gcs-bucket; then
         echo "Failed to mount GCS bucket. Exiting."
         exit 1
     fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,6 +56,10 @@ install_linux_prerequisites() {
         fi
     done
 
+    if ! python3 -c 'import ensurepip, venv' >/dev/null 2>&1; then
+        prerequisites_present=false
+    fi
+
     if [[ "${prerequisites_present}" == true ]] && \
         command -v ldconfig >/dev/null 2>&1 && ldconfig -p 2>/dev/null | grep -Fq 'libicu'; then
         log "Linux prerequisite packages are already installed"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,7 @@ readonly DOTNET_INSTALL_DIR="${HOME}/.dotnet"
 readonly DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 readonly PRE_COMMIT_VERSION="4.6.0"
 readonly PRE_COMMIT_ENV="${HOME}/.local/share/MicroService/pre-commit"
+readonly SONAR_SCANNER_VERSION="11.2.1"
 
 log() {
     printf '[setup] %s\n' "$*"
@@ -43,8 +44,23 @@ run_as_root() {
 
 install_linux_prerequisites() {
     local icu_package
+    local command_name
+    local prerequisites_present=true
 
     [[ -r /etc/os-release ]] || fail "Cannot identify this Linux distribution"
+
+    for command_name in curl git make python3 shellcheck unzip; do
+        if ! command -v "${command_name}" >/dev/null 2>&1; then
+            prerequisites_present=false
+            break
+        fi
+    done
+
+    if [[ "${prerequisites_present}" == true ]] && \
+        command -v ldconfig >/dev/null 2>&1 && ldconfig -p 2>/dev/null | grep -Fq 'libicu'; then
+        log "Linux prerequisite packages are already installed"
+        return
+    fi
 
     # shellcheck disable=SC1091
     source /etc/os-release
@@ -55,10 +71,10 @@ install_linux_prerequisites() {
             icu_package="$(apt-cache pkgnames | grep -E '^libicu[0-9]+$' | sort -V | tail -n 1 || true)"
             [[ -n "${icu_package}" ]] || fail "Could not find the ICU runtime package"
             run_as_root apt-get install -y --no-install-recommends \
-                ca-certificates curl git "${icu_package}" make python3 python3-venv unzip
+                ca-certificates curl git "${icu_package}" make python3 python3-venv shellcheck unzip
             ;;
         *)
-            fail "Unsupported Linux distribution: ${ID:-unknown}. Install curl, git, make, and unzip manually."
+            fail "Unsupported Linux distribution: ${ID:-unknown}. Install curl, git, make, Python 3, ShellCheck, and unzip manually."
             ;;
     esac
 }
@@ -71,6 +87,12 @@ install_macos_prerequisites() {
     for command_name in curl git make python3 unzip; do
         command -v "${command_name}" >/dev/null 2>&1 || fail "Required command not found: ${command_name}"
     done
+
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        command -v brew >/dev/null 2>&1 || fail "Install Homebrew or ShellCheck, then rerun this script"
+        log "Installing ShellCheck with Homebrew"
+        brew install shellcheck
+    fi
 }
 
 install_prerequisites() {
@@ -147,6 +169,24 @@ install_dotnet_sdk() {
     rm -rf -- "${temp_dir}"
 }
 
+install_sonar_scanner() {
+    local installed_version
+
+    installed_version="$(dotnet tool list --global | awk '$1 == "dotnet-sonarscanner" { print $2 }')"
+    if [[ "${installed_version}" == "${SONAR_SCANNER_VERSION}" ]]; then
+        log "SonarScanner for .NET ${SONAR_SCANNER_VERSION} is already installed"
+        return
+    fi
+
+    if [[ -n "${installed_version}" ]]; then
+        log "Updating SonarScanner for .NET from ${installed_version} to ${SONAR_SCANNER_VERSION}"
+        dotnet tool update --global dotnet-sonarscanner --version "${SONAR_SCANNER_VERSION}"
+    else
+        log "Installing SonarScanner for .NET ${SONAR_SCANNER_VERSION}"
+        dotnet tool install --global dotnet-sonarscanner --version "${SONAR_SCANNER_VERSION}"
+    fi
+}
+
 verify_toolchain() {
     local expected_sdk="$1"
     local actual_sdk
@@ -157,6 +197,7 @@ verify_toolchain() {
     log ".NET SDK: ${actual_sdk}"
     log "Git: $(git --version)"
     log "Make: $(make --version | head -n 1)"
+    log "ShellCheck: $(shellcheck --version | sed -n 's/^version: //p')"
 
     if command -v docker >/dev/null 2>&1; then
         log "Docker: $(docker --version)"
@@ -192,6 +233,7 @@ main() {
     sdk_version="$(read_sdk_version)"
     install_prerequisites
     install_dotnet_sdk "${sdk_version}"
+    install_sonar_scanner
     install_pre_commit
     verify_toolchain "${sdk_version}"
     repair_generated_artifact_permissions

--- a/scripts/sonar.sh
+++ b/scripts/sonar.sh
@@ -19,10 +19,25 @@ fail() {
 
 [[ -f "${ENV_FILE}" ]] || fail "Missing ${ENV_FILE}. Define SONAR_HOST_URL and SONAR_TOKEN."
 
-set -a
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
-set +a
+while IFS='=' read -r env_key env_value; do
+    env_value="${env_value%$'\r'}"
+    case "${env_key}" in
+        SONAR_HOST_URL|SONAR_TOKEN)
+            if [[ "${env_value}" == \"*\" && "${env_value}" == *\" ]]; then
+                env_value="${env_value:1:${#env_value}-2}"
+            elif [[ "${env_value}" == \'*\' && "${env_value}" == *\' ]]; then
+                env_value="${env_value:1:${#env_value}-2}"
+            fi
+            if [[ "${env_key}" == "SONAR_HOST_URL" ]]; then
+                SONAR_HOST_URL="${env_value}"
+                export SONAR_HOST_URL
+            else
+                SONAR_TOKEN="${env_value}"
+                export SONAR_TOKEN
+            fi
+            ;;
+    esac
+done < "${ENV_FILE}"
 
 : "${SONAR_HOST_URL:?SONAR_HOST_URL must be set in .env}"
 : "${SONAR_TOKEN:?SONAR_TOKEN must be set in .env}"

--- a/scripts/sonar.sh
+++ b/scripts/sonar.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly REPO_ROOT
+readonly ENV_FILE="${REPO_ROOT}/.env"
+readonly PROJECT_KEY="MicroService.Api"
+readonly SOLUTION="MicroService.sln"
+readonly TEST_PROJECT="test/MicroService.Test/MicroService.Test.csproj"
+readonly RESULTS_DIRECTORY=".test-results/sonar"
+
+fail() {
+    printf '[sonar] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -f "${ENV_FILE}" ]] || fail "Missing ${ENV_FILE}. Define SONAR_HOST_URL and SONAR_TOKEN."
+
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+: "${SONAR_HOST_URL:?SONAR_HOST_URL must be set in .env}"
+: "${SONAR_TOKEN:?SONAR_TOKEN must be set in .env}"
+
+export PATH="${HOME}/.dotnet:${HOME}/.dotnet/tools:${PATH}"
+command -v dotnet >/dev/null 2>&1 || fail ".NET SDK not found. Run 'make setup'."
+command -v dotnet-sonarscanner >/dev/null 2>&1 || fail "SonarScanner not found. Run 'make setup'."
+
+cd "${REPO_ROOT}"
+
+mkdir -p "${RESULTS_DIRECTORY}"
+find "${RESULTS_DIRECTORY}" -mindepth 1 -delete
+
+printf '[sonar] Starting analysis for %s\n' "${PROJECT_KEY}"
+dotnet-sonarscanner begin \
+    "/k:${PROJECT_KEY}" \
+    "/d:sonar.host.url=${SONAR_HOST_URL}" \
+    "/d:sonar.token=${SONAR_TOKEN}" \
+    "/d:sonar.exclusions=src/**/Program.cs,src/**/Extensions/**/*.cs" \
+    "/d:sonar.cs.opencover.reportsPaths=${RESULTS_DIRECTORY}/**/coverage.opencover.xml" \
+    "/d:sonar.cs.vstest.reportsPaths=${RESULTS_DIRECTORY}/*.trx"
+
+dotnet restore "${SOLUTION}"
+dotnet build "${SOLUTION}" --configuration Release --no-restore
+dotnet test "${TEST_PROJECT}" \
+    --configuration Release \
+    --no-build \
+    --logger "trx;LogFileName=tests.trx" \
+    --results-directory "${RESULTS_DIRECTORY}" \
+    --collect "XPlat Code Coverage" \
+    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+
+dotnet-sonarscanner end "/d:sonar.token=${SONAR_TOKEN}"
+printf '[sonar] Analysis submitted successfully\n'

--- a/scripts/update_cloud_run_service.sh
+++ b/scripts/update_cloud_run_service.sh
@@ -19,14 +19,11 @@ echo "Updating Cloud Run service: $SERVICE_NAME in region: $REGION"
 echo "Mounting GCS Bucket: $BUCKET_NAME at $MOUNT_PATH"
 
 # Update the Cloud Run service to mount the GCS bucket
-gcloud beta run services update $SERVICE_NAME \
+if gcloud beta run services update "${SERVICE_NAME}" \
   --execution-environment gen2 \
-  --add-volume=name=$VOLUME_NAME,type=cloud-storage,bucket=$BUCKET_NAME \
-  --add-volume-mount=volume=$VOLUME_NAME,mount-path=$MOUNT_PATH \
-  --region=$REGION  # Specify the region
-
-# Check the exit status of the gcloud command
-if [ $? -eq 0 ]; then
+  --add-volume="name=${VOLUME_NAME},type=cloud-storage,bucket=${BUCKET_NAME}" \
+  --add-volume-mount="volume=${VOLUME_NAME},mount-path=${MOUNT_PATH}" \
+  --region="${REGION}"; then
   echo "Cloud Run service updated successfully."
 else
   echo "Failed to update Cloud Run service."

--- a/sonar.bat
+++ b/sonar.bat
@@ -1,4 +1,0 @@
-dotnet sonarscanner begin /k:"MicroService.Api" /d:sonar.host.url="http://192.168.1.172:9100" /d:sonar.exclusions=Program.cs,**/Extensions/**/*.cs  /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.login="sqp_b0b06eef83dbde81db33f8db66c89554c41f9831"
-dotnet build --no-incremental
-dotnet-coverage collect 'dotnet test' -f xml  -o 'coverage.xml'
-dotnet sonarscanner end /d:sonar.login="sqp_b0b06eef83dbde81db33f8db66c89554c41f9831"


### PR DESCRIPTION
## Summary

- install a pinned SonarScanner for .NET and ShellCheck through the local setup workflow
- replace the credential-bearing Windows-only Sonar script with a cross-platform `make sonar` workflow
- submit Release builds, test results, and OpenCover coverage to the `MicroService.Api` SonarQube project
- add ShellCheck and codespell pre-commit checks and correct the existing findings
- ignore local `.env` credentials and avoid stale coverage data between analyses

## Why

The repository's existing SonarQube script was Windows-specific and contained an obsolete server address and hard-coded token. Local analysis was not reproducible through the current setup or Make workflows, and shell scripts and prose had no automated linting.

## Developer impact

Run `make setup` to install the required tools, define `SONAR_HOST_URL` and `SONAR_TOKEN` in the ignored `.env`, then run `make sonar` to build, test, collect coverage, and submit analysis.

## Validation

- `make setup`
- `make check`
- SonarScanner for .NET 11.2.1 analysis submitted and processed successfully
- .NET 10 Release build succeeded
- tests: 221 passed, 12 skipped, 0 failed
- OpenCover coverage and TRX results imported successfully
- SonarQube quality gate passed
- `git diff --check`

SonarQube baseline: 66.5% coverage, 5 bugs, 7 vulnerabilities, 420 code smells, and 3.6% duplicated lines.
