### PR TITLE
Remediate vulnerable NuGet dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/renovate.json
+++ b/renovate.json
@@ -3,16 +3,100 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": true,
+  "labels": [
+    "dependencies"
+  ],
   "packageRules": [
     {
-      "description": "Group all GitHub Actions updates into one pull request",
+      "description": "Group GitHub Actions updates",
       "matchManagers": [
         "github-actions"
       ],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions",
-      "groupSingleUpdates": true,
       "separateMajorMinor": false
+    },
+    {
+      "description": "Group Microsoft runtime packages",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "Microsoft.Extensions.*",
+        "Microsoft.IdentityModel.*",
+        "System.IdentityModel.*"
+      ],
+      "groupName": "Microsoft .NET runtime packages",
+      "groupSlug": "microsoft-dotnet-runtime"
+    },
+    {
+      "description": "Group OpenTelemetry packages",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "OpenTelemetry*"
+      ],
+      "groupName": "OpenTelemetry",
+      "groupSlug": "opentelemetry"
+    },
+    {
+      "description": "Group ASP.NET Core health check packages",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "AspNetCore.HealthChecks.*"
+      ],
+      "groupName": "ASP.NET Core health checks",
+      "groupSlug": "aspnet-health-checks"
+    },
+    {
+      "description": "Group Swagger packages",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "Swashbuckle.AspNetCore*"
+      ],
+      "groupName": "Swashbuckle",
+      "groupSlug": "swashbuckle"
+    },
+    {
+      "description": "Group geospatial packages",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "NetTopologySuite*",
+        "ProjNet"
+      ],
+      "groupName": "Geospatial packages",
+      "groupSlug": "geospatial"
+    },
+    {
+      "description": "Group test infrastructure packages",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "coverlet.collector",
+        "Microsoft.NET.Test.Sdk",
+        "xunit",
+        "xunit.runner.visualstudio"
+      ],
+      "groupName": ".NET test infrastructure",
+      "groupSlug": "dotnet-test-infrastructure"
+    },
+    {
+      "description": "Group Docker image updates",
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose"
+      ],
+      "groupName": "Docker images",
+      "groupSlug": "docker-images"
     }
   ]
 }

--- a/src/MicroService.Common/MicroService.Common.csproj
+++ b/src/MicroService.Common/MicroService.Common.csproj
@@ -12,12 +12,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
 		<PackageReference Include="AspNetCore.HealthChecks.System" Version="8.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
+		<PackageReference Include="KubernetesClient" Version="17.0.14" />
 		<PackageReference Include="Flurl" Version="4.0.0" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 		<PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />

--- a/src/MicroService.Data/MicroService.Data.csproj
+++ b/src/MicroService.Data/MicroService.Data.csproj
@@ -11,8 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.28" />
-		<PackageReference Include="Npgsql" Version="8.0.2" />
-		<PackageReference Include="System.ComponentModel" Version="4.3.0" />
+		<PackageReference Include="Npgsql" Version="8.0.3" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>
 

--- a/src/MicroService.Service/MicroService.Service.csproj
+++ b/src/MicroService.Service/MicroService.Service.csproj
@@ -10,10 +10,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="13.0.1" />
+		<PackageReference Include="AutoMapper" Version="15.1.1" />
 		<PackageReference Include="CsvHelper" Version="31.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
 		<PackageReference Include="NetTopologySuite" Version="2.5.0" />
 		<PackageReference Include="NetTopologySuite.Features" Version="2.1.0" />
 		<PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />

--- a/src/MicroService.WebApi/MicroService.WebApi.csproj
+++ b/src/MicroService.WebApi/MicroService.WebApi.csproj
@@ -24,17 +24,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Jaeger" Version="1.0.3" />
-		<PackageReference Include="Jaeger.Core" Version="1.0.3" />
-		<PackageReference Include="Jaeger.Senders.Thrift" Version="1.0.3" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-		<PackageReference Include="OpenTelemetry" Version="1.7.0" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+		<PackageReference Include="OpenTelemetry" Version="1.17.0" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.17.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MicroService.WebApi/Program.cs
+++ b/src/MicroService.WebApi/Program.cs
@@ -63,11 +63,11 @@ void SetupConfiguration()
 
 void SetupMappings()
 {
-    services.AddSingleton(_ => new MapperConfiguration(cfg =>
+    services.AddSingleton(serviceProvider => new MapperConfiguration(cfg =>
     {
         //cfg.Internal().AllowAdditiveTypeMapCreation = true;
         cfg.AddMaps(typeof(BoroughBoundaryShapeProfile).Assembly);
-    }).CreateMapper());
+    }, serviceProvider.GetRequiredService<ILoggerFactory>()).CreateMapper());
 }
 
 void SetupServices()

--- a/test/MicroService.Test/Fixture/ShapeServiceFixture.cs
+++ b/test/MicroService.Test/Fixture/ShapeServiceFixture.cs
@@ -88,11 +88,11 @@ namespace MicroService.Test.Fixture
                 .Configure<ApplicationOptions>(Configuration)
                 .AddSingleton(Configuration)
 
-                .AddSingleton(_ => new MapperConfiguration(cfg =>
+                .AddSingleton(serviceProvider => new MapperConfiguration(cfg =>
                 {
                     //cfg.Internal().AllowAdditiveTypeMapCreation = true;
                     cfg.AddMaps(typeof(BoroughBoundaryShapeProfile).Assembly);
-                }).CreateMapper())
+                }, serviceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>()).CreateMapper())
 
                 .BuildServiceProvider();
 

--- a/test/MicroService.Test/Mappings/Base/BaseMapper.cs
+++ b/test/MicroService.Test/Mappings/Base/BaseMapper.cs
@@ -12,7 +12,7 @@ namespace MicroService.Test.Mappings.Base
             var mapperConfig = new MapperConfiguration(config =>
             {
                 config.AddMaps(typeof(BoroughBoundaryShapeProfile).Assembly);
-            });
+            }, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
 
             Mapper = mapperConfig.CreateMapper();
         }

--- a/test/MicroService.Test/Mappings/ShapeMappingsTests.cs
+++ b/test/MicroService.Test/Mappings/ShapeMappingsTests.cs
@@ -13,7 +13,7 @@ namespace MicroService.Test.Mappings
             var mapperConfig = new MapperConfiguration(cfg =>
             {
                 cfg.AddMaps(typeof(BoroughBoundaryShapeProfile).Assembly);
-            });
+            }, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
 
             // Act and Assert
             mapperConfig.AssertConfigurationIsValid();
@@ -21,4 +21,3 @@ namespace MicroService.Test.Mappings
 
     }
 }
-


### PR DESCRIPTION
## Summary

- update vulnerable Npgsql, AutoMapper, OpenTelemetry, HealthChecks, KubernetesClient, and Microsoft Extensions dependencies
- remove unused vulnerable Jaeger packages and the obsolete System.ComponentModel reference
- adapt AutoMapper configuration to its patched API
- fail restore on future NU1901-NU1904 NuGet audit findings
- organize Renovate updates by dependency family and ecosystem

## Why

The previous dependency graph contained high- and moderate-severity direct and transitive vulnerabilities. Several related packages also drifted across incompatible version lines, and Renovate only grouped GitHub Actions updates.

## Developer impact

Restore now audits all transitive dependencies and treats known NuGet vulnerabilities as errors. Related Renovate updates will be grouped for GitHub Actions, Microsoft runtime packages, OpenTelemetry, HealthChecks, Swashbuckle, geospatial packages, test infrastructure, and Docker images.

## Validation

- transitive NuGet vulnerability audit: zero findings
- Renovate configuration validator: passed
- .NET 10 Release build: passed
- tests: 221 passed, 12 skipped, 0 failed
- pre-commit, ShellCheck, and codespell: passed
- `git diff --check`: passed

## Follow-up work

Deprecated API versioning, shapefile, and xUnit v2 packages require dedicated migrations and are intentionally excluded from this security-focused PR.
