### PR TITLE
Migrate ASP.NET API versioning

### DIFF
--- a/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
-﻿using MicroService.Service.Configuration;
+﻿using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
+using MicroService.Service.Configuration;
 using MicroService.Service.Models.Enum;
 using MicroService.WebApi.Extensions.Constants;
 using MicroService.WebApi.Services.Cron;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using OpenTelemetry.Resources;
@@ -64,9 +65,9 @@ namespace MicroService.WebApi.Extensions
         /// <param name="services"></param>
         public static void AddCustomApiVersioning(this IServiceCollection services)
         {
-            _ = services.AddApiVersioning(options => { options.ReportApiVersions = true; });
-
-            _ = services.AddVersionedApiExplorer(
+            _ = services.AddApiVersioning(options => { options.ReportApiVersions = true; })
+                .AddMvc()
+                .AddApiExplorer(
                 options =>
                 {
                     // add the versioned api explorer, which also adds IApiVersionDescriptionProvider service

--- a/src/MicroService.WebApi/Extensions/Swagger/ConfigureSwaggerOptions.cs
+++ b/src/MicroService.WebApi/Extensions/Swagger/ConfigureSwaggerOptions.cs
@@ -1,5 +1,5 @@
-﻿using MicroService.WebApi.Extensions.Constants;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
+﻿using Asp.Versioning.ApiExplorer;
+using MicroService.WebApi.Extensions.Constants;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/MicroService.WebApi/MicroService.WebApi.csproj
+++ b/src/MicroService.WebApi/MicroService.WebApi.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="CronExpressionDescriptor" Version="2.21.0" />
 		<PackageReference Include="Cronos" Version="0.7.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
+		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/src/MicroService.WebApi/Program.cs
+++ b/src/MicroService.WebApi/Program.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using Asp.Versioning.ApiExplorer;
+using AutoMapper;
 using HealthChecks.UI.Client;
 using MicroService.Common.Constants;
 using MicroService.Common.Health;
@@ -19,7 +20,6 @@ using MicroService.WebApi.Extensions;
 using MicroService.WebApi.Extensions.Swagger;
 using MicroService.WebApi.Services;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;

--- a/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
@@ -1,4 +1,5 @@
-﻿using MicroService.Service.Helpers;
+﻿using Asp.Versioning;
+using MicroService.Service.Helpers;
 using MicroService.Service.Interfaces;
 using MicroService.Service.Models.Base;
 using MicroService.Service.Models.Enum;

--- a/src/MicroService.WebApi/V1/Controllers/FlatFileServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/FlatFileServiceController.cs
@@ -1,4 +1,5 @@
-﻿using MicroService.Service.Helpers;
+﻿using Asp.Versioning;
+using MicroService.Service.Helpers;
 using MicroService.Service.Models.Enum;
 using MicroService.Service.Models.Enum.Attributes;
 using MicroService.Service.Models.FlatFileModels;

--- a/src/MicroService.WebApi/V1/Controllers/TestDataController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/TestDataController.cs
@@ -1,4 +1,5 @@
-﻿using MicroService.Data.Models;
+﻿using Asp.Versioning;
+using MicroService.Data.Models;
 using MicroService.Data.Repository;
 using MicroService.Service.Constants;
 using MicroService.Service.Interfaces;

--- a/src/MicroService.WebApi/V1/Controllers/TransformationServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/TransformationServiceController.cs
@@ -1,4 +1,5 @@
-﻿using MicroService.Service.Helpers;
+﻿using Asp.Versioning;
+using MicroService.Service.Helpers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MicroService.WebApi.V1.Controllers


### PR DESCRIPTION
## Summary

- replace deprecated `Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer` with `Asp.Versioning.Mvc.ApiExplorer` 10.0.1
- migrate API versioning registration to the current builder-based API
- update API versioning and API Explorer namespaces across Swagger and controllers

## Why

The Microsoft-branded API versioning packages are deprecated and no longer maintained. The supported packages use the `Asp.Versioning` namespace and a composable registration API.

## Developer impact

Existing URL-segment versioning, reported API versions, version substitution, controller attributes, and per-version Swagger documents are preserved.

## Validation

- .NET 10 Release build: passed
- tests: 221 passed, 12 skipped, 0 failed
- deprecated package audit confirms the old API versioning packages are removed
- pre-commit, ShellCheck, and codespell: passed
- `git diff --check`: passed

## Dependency

This is a stacked PR based on `agent/remediate-nuget-dependencies` and should merge after PR #450.
