### PR TITLE
Update Dapper and Npgsql for .NET 10

### DIFF
--- a/src/MicroService.Data/MicroService.Data.csproj
+++ b/src/MicroService.Data/MicroService.Data.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.1.28" />
-		<PackageReference Include="Npgsql" Version="8.0.3" />
+		<PackageReference Include="Dapper" Version="2.1.79" />
+		<PackageReference Include="Npgsql" Version="10.0.3" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary
- update Dapper from 2.1.28 to 2.1.79
- update Npgsql from 8.0.3 to 10.0.3
- align the PostgreSQL driver major version with the .NET 10 target

## Validation
- `dotnet build MicroService.sln --configuration Release --no-restore`
- `dotnet test test/MicroService.Test/MicroService.Test.csproj --configuration Release --no-build` (221 passed, 12 skipped, 0 failed)
- `pre-commit run --all-files`

## Dependency
This is a stacked PR and should be merged after #453.