### PR TITLE
Add project-local agent and PR workflow rules

### DIFF
--- a/.github/instructions/pull-requests.instructions.md
+++ b/.github/instructions/pull-requests.instructions.md
@@ -1,0 +1,76 @@
+---
+applyTo: "**"
+---
+
+# Pull Request and Review Rules
+
+These rules apply to every change proposed to this repository.
+
+## Branch and Validation Requirements
+
+1. Never commit or push directly to `master`.
+2. Create a focused branch for each independently reviewable change.
+3. Before publishing a pull request, run:
+   - `make check`
+   - `make build`
+   - `make test`
+4. Resolve conflicts and verify that the intended diff contains no unrelated
+   files or secrets.
+
+## Creating Pull Requests
+
+1. Create pull requests as **ready for review**, not as drafts, once local
+   validation passes.
+2. Include a concise summary, validation commands and results, dependency or
+   stack information, and any known risks in the description.
+3. A ready-for-review PR is not automatically merge-ready.
+4. Do not enable auto-merge or add the PR to a merge queue during creation.
+
+## Stacked Pull Requests
+
+Use GitHub stacked pull requests when work depends on an unmerged change:
+
+1. The bottom PR targets `master`.
+2. Each higher PR targets the head branch of the PR immediately below it.
+3. Each layer must contain one focused change and pass validation independently.
+4. Link the PRs as a GitHub stack so default-branch rules and CI apply to every
+   layer.
+5. Put fixes in the layer where they logically belong, then perform a cascading
+   rebase and rerun validation for affected layers.
+6. Merge the top PR only when the entire stack satisfies the merge-readiness
+   requirements below. GitHub will merge the stack from the bottom up.
+
+## Copilot Review Gate
+
+GitHub Copilot review is a mandatory procedural gate:
+
+1. Wait until GitHub Copilot has completed its review of every PR in the stack.
+2. Inspect every Copilot comment; do not treat an absent, pending, or failed
+   review as approval.
+3. For each actionable comment:
+   - implement the fix in the correct stack layer;
+   - run the relevant lint, build, and test commands;
+   - push the fix;
+   - reply directly to the review thread with what changed, the commit SHA, and
+     the validation that passed;
+   - request or wait for follow-up review when GitHub offers it.
+4. Resolve a thread only after the concern is addressed or a documented,
+   technically supported reason for not changing the code is accepted.
+5. Re-check Copilot review state after every force-push or cascading rebase.
+
+## Merge-Readiness Checklist
+
+Do not state that a PR or stack is merge-ready and do not merge it until all of
+the following are true:
+
+- [ ] The PR is ready for review and conflict-free.
+- [ ] Required lint, build, and test checks pass on the current head SHA.
+- [ ] GitHub Copilot has completed its review on every affected PR.
+- [ ] Every actionable review comment has been addressed and replied to.
+- [ ] Required review threads are resolved.
+- [ ] No newer commit or rebase invalidated the completed review or CI results.
+- [ ] For a stack, every layer satisfies this checklist.
+
+The final merge remains an explicit user or maintainer decision. Agents must
+report the evidence and ask for confirmation before performing that irreversible
+action unless the user has already explicitly authorized the merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Operating Guide
+
+All automation, assistants, and developers must follow the project instructions
+under `.github/instructions/`.
+
+## Project Commands
+
+- Setup: `make setup`
+- Restore and build: `make build`
+- Test: `make test`
+- Run all local checks: `make check`
+- Run pre-commit directly: `pre-commit run --all-files`
+
+## Pull Request Workflow
+
+Follow `.github/instructions/pull-requests.instructions.md` for every pull
+request. In particular:
+
+- Never commit directly to `master`.
+- Create focused branches and pull requests that are ready for review, not
+  drafts, after local validation passes.
+- Use a GitHub stacked pull request when a change depends on an unmerged pull
+  request. Keep the bottom PR based on `master` and each higher PR based on the
+  branch immediately below it.
+- Do not describe a PR or stack as merge-ready, enable auto-merge, add it to a
+  merge queue, or merge it until GitHub Copilot has completed its review.
+- Address every actionable Copilot comment, reply with the resolution and
+  validation evidence, and wait for any requested follow-up review.
+- A PR is merge-ready only when required CI passes, Copilot review is complete,
+  actionable review threads are resolved, and the PR is conflict-free.
+
+## Safety
+
+- Do not commit `.env`, credentials, tokens, or generated secrets.
+- Preserve unrelated working-tree changes and explicitly stage only files that
+  belong to the current change.
+- Use `--force-with-lease` only when a stack rebase requires rewriting a
+  feature branch; never force-push `master`.


### PR DESCRIPTION
## Summary
- add a root `AGENTS.md` operating guide for Codex and repository automation
- add path-scoped Copilot instructions for branch, validation, and PR creation rules
- standardize GitHub stacked PR construction and cascading review behavior
- require completed GitHub Copilot review and resolved actionable feedback before a PR or stack can be considered merge-ready
- require explicit maintainer confirmation before an agent performs the final merge

## Validation
- `git diff --check`
- `pre-commit run --files AGENTS.md .github/instructions/pull-requests.instructions.md`

## Review state
This PR is ready for review but is intentionally **not merge-ready** until GitHub Copilot completes its review and any actionable feedback is resolved.

## Dependency
This PR is the top layer above #454.