### PR TITLE
Fix deployment health validation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -204,9 +204,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-googlecloud
     env:
-      HEALTH_URL: ${{ needs.deploy-googlecloud.outputs.url }}/health
+      HEALTH_URL: ${{ needs['deploy-googlecloud'].outputs.url }}/health
       MAX_ATTEMPTS: 15
       RETRY_DELAY_SECONDS: 5
+      CONNECT_TIMEOUT_SECONDS: 10
+      REQUEST_TIMEOUT_SECONDS: 30
     steps:
       - run: |
           set -euo pipefail
@@ -221,6 +223,8 @@ jobs:
             --show-error \
             --silent \
             --location \
+            --connect-timeout "${CONNECT_TIMEOUT_SECONDS}" \
+            --max-time "${REQUEST_TIMEOUT_SECONDS}" \
             --retry "${MAX_ATTEMPTS}" \
             --retry-delay "${RETRY_DELAY_SECONDS}" \
             --retry-connrefused \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -204,12 +204,34 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-googlecloud
     env:
-      url: ${{ needs.deploy.outputs.url }}/health
-      max-attempts: 15
-      retry-delay-sec: 5
+      HEALTH_URL: ${{ needs.deploy-googlecloud.outputs.url }}/health
+      MAX_ATTEMPTS: 15
+      RETRY_DELAY_SECONDS: 5
     steps:
       - run: |
-          curl --fail -s --retry ${{ env.max-attempts }} --retry-delay ${{ env.retry-delay-sec }} --retry-connrefused ${{ env.url }} -L  | jq
+          set -euo pipefail
+
+          if [[ "${HEALTH_URL}" == "/health" ]]; then
+            echo "Cloud Run deployment URL was not provided" >&2
+            exit 1
+          fi
+
+          response="$(curl \
+            --fail \
+            --show-error \
+            --silent \
+            --location \
+            --retry "${MAX_ATTEMPTS}" \
+            --retry-delay "${RETRY_DELAY_SECONDS}" \
+            --retry-connrefused \
+            "${HEALTH_URL}")"
+
+          if [[ "${response}" != "Healthy" ]]; then
+            echo "Unexpected health response: ${response}" >&2
+            exit 1
+          fi
+
+          echo "Deployment health check passed: ${HEALTH_URL}"
 
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- use the actual `deploy-googlecloud` job output for the deployed Cloud Run URL
- fail when the deployment URL is missing or the health endpoint is unreachable
- validate the endpoint’s plain-text `Healthy` response instead of piping it to `jq`

## Root cause

The health job referenced a nonexistent `deploy` dependency, which reduced the URL to `/health`. The curl failure was then masked by the pipeline and `jq` accepted empty input, allowing a false-positive deployment check.

## Validation

- `actionlint .github/workflows/actions.yml`
- `pre-commit run --all-files`
- `make build CONFIGURATION=Release`
- `make test CONFIGURATION=Release` (221 passed, 12 skipped)

## Stack

Depends on #455 and is intended as the new top of stack #452. This PR is ready for review, but should not be merged until CI and GitHub Copilot review complete.