### PR TITLE
Update test tooling packages

### DIFF
--- a/test/MicroService.Test/MicroService.Test.csproj
+++ b/test/MicroService.Test/MicroService.Test.csproj
@@ -20,12 +20,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-		<PackageReference Include="Moq" Version="4.20.70" />
+		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- update coverlet.collector from 6.0.0 to 10.0.1
- update Moq from 4.20.70 to 4.20.72

## Impact

Refreshes test coverage collection and applies the latest Moq patch without changing production dependencies.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)

## Stack

Bottom layer of the dependency update stack. Ready for review; do not merge until CI and Copilot review complete.