### PR TITLE
Update geospatial packages

### DIFF
--- a/src/MicroService.Service/MicroService.Service.csproj
+++ b/src/MicroService.Service/MicroService.Service.csproj
@@ -14,12 +14,12 @@
 		<PackageReference Include="CsvHelper" Version="31.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
-		<PackageReference Include="NetTopologySuite" Version="2.5.0" />
-		<PackageReference Include="NetTopologySuite.Features" Version="2.1.0" />
+		<PackageReference Include="NetTopologySuite" Version="2.6.0" />
+		<PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />
 		<PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
 		<PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
 		<PackageReference Include="NetTopologySuite.IO.ShapeFile" Version="2.1.0" />
-		<PackageReference Include="ProjNet" Version="2.0.0" />
+		<PackageReference Include="ProjNet" Version="2.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- update NetTopologySuite from 2.5.0 to 2.6.0
- update NetTopologySuite.Features from 2.1.0 to 2.2.0
- update ProjNet from 2.0.0 to 2.1.0

## Impact

Updates the related geospatial package family together while retaining the existing application behavior and public API.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)

## Stack

Depends on the test tooling update immediately below it. Ready for review; do not merge until CI and Copilot review complete.