### PR TITLE
Update health check packages

### DIFF
--- a/src/MicroService.Common/MicroService.Common.csproj
+++ b/src/MicroService.Common/MicroService.Common.csproj
@@ -12,12 +12,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
-		<PackageReference Include="AspNetCore.HealthChecks.System" Version="8.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
+		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.System" Version="9.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
 		<PackageReference Include="KubernetesClient" Version="17.0.14" />
 		<PackageReference Include="Flurl" Version="4.0.0" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />


### PR DESCRIPTION
## Summary

- update the AspNetCore.HealthChecks PostgreSQL, system, URI, UI, UI client, and in-memory storage packages to 9.0.0
- keep the related health-check family aligned in one change

## Impact

Refreshes runtime health monitoring dependencies while preserving the existing health endpoint and configuration.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)

## Stack

Bottom layer of the runtime infrastructure dependency stack. Ready for review; do not merge until CI and Copilot review complete.