### PR TITLE
Update Serilog packages

### DIFF
--- a/src/MicroService.Common/MicroService.Common.csproj
+++ b/src/MicroService.Common/MicroService.Common.csproj
@@ -22,12 +22,12 @@
 		<PackageReference Include="Flurl" Version="4.0.0" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 		<PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
-		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-		<PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
+		<PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- update Serilog.AspNetCore to 10.0.0
- update environment and thread enrichers
- update console and Grafana Loki sinks

## Impact

Aligns the application logging stack with .NET 10-era Serilog packages without changing logging configuration or behavior.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)

## Stack

Depends on the health-check package layer. Ready for review; do not merge until CI and Copilot review complete.