### PR TITLE
Update Kubernetes client

### DIFF
--- a/src/MicroService.Common/MicroService.Common.csproj
+++ b/src/MicroService.Common/MicroService.Common.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
-		<PackageReference Include="KubernetesClient" Version="17.0.14" />
+		<PackageReference Include="KubernetesClient" Version="19.0.2" />
 		<PackageReference Include="Flurl" Version="4.0.0" />
 		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 		<PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />


### PR DESCRIPTION
## Summary

- update KubernetesClient from 17.0.14 to 19.0.2

## Impact

Moves the Kubernetes API client to its current major release. Existing project usage compiles without source changes and the full test suite remains green.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)

## Stack

Top layer of the runtime infrastructure dependency stack. Ready for review; do not merge until CI and Copilot review complete.