### PR TITLE
Update AutoMapper to 16

### DIFF
--- a/src/MicroService.Service/MicroService.Service.csproj
+++ b/src/MicroService.Service/MicroService.Service.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="15.1.1" />
+		<PackageReference Include="AutoMapper" Version="16.2.0" />
 		<PackageReference Include="CsvHelper" Version="33.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />


### PR DESCRIPTION
## Summary

- update AutoMapper from 15.1.1 to 16.2.0
- retain the existing logger-factory-aware configuration introduced for AutoMapper 15

## Impact

Completes the AutoMapper major-version update without requiring application source changes.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)

## Stack

Bottom layer of the final direct NuGet dependency stack. Ready for review; do not merge until CI and Copilot review complete.