### PR TITLE
Migrate to Swashbuckle 10

### DIFF
--- a/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -5,13 +5,13 @@ using MicroService.Service.Models.Enum;
 using MicroService.WebApi.Extensions.Constants;
 using MicroService.WebApi.Services.Cron;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Swashbuckle.AspNetCore.Filters;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json.Nodes;
 
 namespace MicroService.WebApi.Extensions
 {
@@ -96,25 +96,18 @@ namespace MicroService.WebApi.Extensions
                     Type = SecuritySchemeType.ApiKey,
                     Scheme = "Bearer"
                 });
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement {
                     {
-                        new OpenApiSecurityScheme
-                        {
-                            Reference = new OpenApiReference
-                            {
-                                Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
-                                Id = "Bearer"
-                            }
-                        },
-                        Array.Empty<string>()
+                        new OpenApiSecuritySchemeReference("Bearer", document, null),
+                        new List<string>()
                     }
                 });
                 c.MapType<ShapeProperties>(() => new OpenApiSchema
                 {
-                    Type = "string",
+                    Type = JsonSchemaType.String,
                     Enum = Enum.GetNames(typeof(ShapeProperties))
-                        .Select(name => new OpenApiString(name))
-                        .Cast<IOpenApiAny>()
+                        .Select(name => JsonValue.Create(name))
+                        .Cast<JsonNode>()
                         .ToList(),
                 });
 

--- a/src/MicroService.WebApi/Extensions/Swagger/ConfigureSwaggerOptions.cs
+++ b/src/MicroService.WebApi/Extensions/Swagger/ConfigureSwaggerOptions.cs
@@ -1,7 +1,7 @@
 ﻿using Asp.Versioning.ApiExplorer;
 using MicroService.WebApi.Extensions.Constants;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroService.WebApi.Extensions.Swagger

--- a/src/MicroService.WebApi/Extensions/Swagger/SwaggerDocumentFilter.cs
+++ b/src/MicroService.WebApi/Extensions/Swagger/SwaggerDocumentFilter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroService.WebApi.Extensions.Swagger
@@ -16,7 +16,7 @@ namespace MicroService.WebApi.Extensions.Swagger
                 throw new ArgumentNullException(nameof(swaggerDoc));
             }
 
-            swaggerDoc.Tags = new List<OpenApiTag> { new OpenApiTag { Name = "RoutingApi", Description = "This is a description for the api routes" }, };
+            swaggerDoc.Tags = new HashSet<OpenApiTag> { new OpenApiTag { Name = "RoutingApi", Description = "This is a description for the api routes" }, };
         }
     }
 }

--- a/src/MicroService.WebApi/MicroService.WebApi.csproj
+++ b/src/MicroService.WebApi/MicroService.WebApi.csproj
@@ -18,9 +18,9 @@
 		<PackageReference Include="Cronos" Version="0.13.0" />
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- update Swashbuckle.AspNetCore and annotations from 6.5.0 to 10.2.3
- update Swashbuckle.AspNetCore.Filters from 8.0.0 to 10.0.1
- migrate Microsoft.OpenApi imports and model APIs
- update security scheme references, enum schemas, JSON schema types, and document tags

## Impact

Moves Swagger generation to the current package line while preserving versioned documents, bearer authentication metadata, enum schemas, and the existing Swagger UI endpoints.

## Validation

- make check
- make build CONFIGURATION=Release
- make test CONFIGURATION=Release (221 passed, 12 skipped)
- isolated local runtime smoke test: /health, /swagger/v1/swagger.json, and /swagger/index.html returned HTTP 200
- dotnet package list --project MicroService.sln --outdated --format json reports no outdated direct packages

## Stack

Top layer of the final direct NuGet dependency stack. Ready for review; do not merge until CI and Copilot review complete.