### PR TITLE
Harden the Web API development container

### DIFF
--- a/src/MicroService.WebApi/Dockerfile
+++ b/src/MicroService.WebApi/Dockerfile
@@ -1,31 +1,22 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+
 ARG APPLICATION_NAME='MicroService.WebApi'
 ARG BUILD_DATE='1/1/2023'
 ARG BUILD_NUMBER=0
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
-
 LABEL org.label-schema.application=${APPLICATION_NAME}
 LABEL org.label-schema.build-date=${BUILD_DATE}
-LABEL org.label-schema.version=7.0.1.${BUILD_NUMBER}
+LABEL org.label-schema.version=10.0.1.${BUILD_NUMBER}
 
+USER app
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
+EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
-
-RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
-RUN rm packages-microsoft-prod.deb
-
-RUN apt-get update && apt-get install -y dotnet-sdk-6.0
-
-ENV PATH="/root/.dotnet/tools:${PATH}"
-RUN dotnet tool install --global dotnet-setversion --version 2.5.0
-RUN dotnet tool list -g
-
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /src
+COPY ["global.json", "."]
 COPY ["NuGet.config", "."]
 COPY ["src/MicroService.WebApi/MicroService.WebApi.csproj", "src/MicroService.WebApi/"]
 COPY ["src/MicroService.Common/MicroService.Common.csproj", "src/MicroService.Common/"]
@@ -37,9 +28,8 @@ WORKDIR "/src/src/MicroService.WebApi"
 RUN dotnet build "MicroService.WebApi.csproj" -c Release -o /app/build
 
 FROM build AS publish
-ARG BUILD_NUMBER
-RUN setversion 7.0.1.${BUILD_NUMBER}
-RUN dotnet publish "MicroService.WebApi.csproj" -c Release -o /app/publish /p:UseAppHost=false
+ARG BUILD_NUMBER=0
+RUN dotnet publish "MicroService.WebApi.csproj" -c Release -o /app/publish /p:UseAppHost=false /p:Version=10.0.1.${BUILD_NUMBER}
 
 FROM base AS final
 
@@ -48,4 +38,5 @@ COPY files  /files
 
 WORKDIR /app
 COPY --from=publish /app/publish .
+USER app
 ENTRYPOINT ["dotnet", "MicroService.WebApi.dll"]

--- a/src/MicroService.WebApi/Dockerfile
+++ b/src/MicroService.WebApi/Dockerfile
@@ -29,7 +29,11 @@ RUN dotnet build "MicroService.WebApi.csproj" -c Release -o /app/build
 
 FROM build AS publish
 ARG BUILD_NUMBER=0
-RUN dotnet publish "MicroService.WebApi.csproj" -c Release -o /app/publish /p:UseAppHost=false /p:Version=10.0.1.${BUILD_NUMBER}
+RUN dotnet publish "MicroService.WebApi.csproj" \
+    -c Release \
+    -o /app/publish \
+    /p:UseAppHost=false \
+    /p:Version=10.0.1.${BUILD_NUMBER}
 
 FROM base AS final
 


### PR DESCRIPTION
## Summary
- migrate the Visual Studio Web API Dockerfile from .NET 7 to .NET 10
- scope Docker build arguments to the stages that consume them
- run the final image as the built-in non-root `app` user on ports 8080/8081
- remove obsolete .NET 6 SDK and `dotnet-setversion` installation

## Validation
- independent `docker build` completed successfully
- image metadata confirms runtime user `app`
- `make check`
- `make build`
- `make test` — 221 passed, 12 skipped

## Risk
Low to moderate. The deployment workflow uses a separate already-.NET-10 Dockerfile; this layer modernizes the Visual Studio development Dockerfile.

## Stack
Layer 3 of stack #472; depends on #469.