### PR TITLE
Define valid targets for model attributes

### DIFF
--- a/src/MicroService.Service/Models/Enum/Attributes/FeatureAttribute.cs
+++ b/src/MicroService.Service/Models/Enum/Attributes/FeatureAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace MicroService.Service.Models.Enum.Attributes
 {
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FeatureNameAttribute : Attribute
     {
         public FeatureNameAttribute(string attributeName)
@@ -12,16 +13,19 @@ namespace MicroService.Service.Models.Enum.Attributes
         public string AttributeName { get; set; }
     }
 
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FeatureCollectionAttribute : Attribute
     {
         public string Name { get; set; }
     }
 
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FeatureCollectionExcludeAttribute : Attribute
     {
         public string Name { get; set; }
     }
 
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class MappingKeyAttribute : Attribute
     {
         public MappingKeyAttribute(string attributeName)

--- a/src/MicroService.Service/Models/Enum/Attributes/FlatFileAttribute.cs
+++ b/src/MicroService.Service/Models/Enum/Attributes/FlatFileAttribute.cs
@@ -1,5 +1,6 @@
 ﻿namespace MicroService.Service.Models.Enum.Attributes
 {
+    [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
     public class FlatFileAttribute : System.Attribute
     {
         public FlatFileAttribute(string directory, string fileName, string modelName, FileTypes fileType)

--- a/src/MicroService.Service/Models/Enum/Attributes/ShapeAttribute.cs
+++ b/src/MicroService.Service/Models/Enum/Attributes/ShapeAttribute.cs
@@ -1,5 +1,6 @@
 ﻿namespace MicroService.Service.Models.Enum.Attributes
 {
+    [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
     public class ShapeAttribute : System.Attribute
     {
         public ShapeAttribute(string directory, string fileName, Datum datum)

--- a/src/MicroService.Service/Models/Enum/Attributes/ShapeStyle.cs
+++ b/src/MicroService.Service/Models/Enum/Attributes/ShapeStyle.cs
@@ -1,5 +1,6 @@
 ﻿namespace MicroService.Service.Models.Enum.Attributes
 {
+    [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
     public class ShapeStyleAttribute : System.Attribute
     {
         public ShapeStyleAttribute(Color color)


### PR DESCRIPTION
## Summary
- define explicit `AttributeUsage` metadata for the project custom attributes
- restrict model mapping attributes to properties and enum metadata attributes to fields
- resolve seven Sonar S3993 findings without changing runtime behavior

## Validation
- `make check`
- `make build`
- `make test` (226 passed, 12 skipped)
- top-stack `make sonar` confirms no remaining S3993 findings

## Stack
- Bottom of stack #476; targets `master`
- Followed by #474 and #475

## Risk
Low. Existing attribute usage was audited and matches the declared targets.