### PR TITLE
Clarify xUnit integration test contracts

### DIFF
--- a/test/MicroService.Test/Integration/CommunityDistrictServiceTest.cs
+++ b/test/MicroService.Test/Integration/CommunityDistrictServiceTest.cs
@@ -91,8 +91,9 @@ namespace MicroService.Test.Integration
 
         [InlineData(312, "", "312")]
         [Theory(Skip = "TODO-FIX", DisplayName = "Get Feature Attribute Lookup")]
-        public void Get_Feature_Attribute_Lookup(object value1, object value2, string expected)
+        public void Get_Feature_Attribute_Lookup(object value1, object _value2, string expected)
         {
+            _ = _value2; // Required by the shared shape-test contract.
             var attributes = new List<KeyValuePair<string, object>>
             {
                 new("BoroCd", value1),

--- a/test/MicroService.Test/Integration/IndividualLandmarkSiteServiceTest.cs
+++ b/test/MicroService.Test/Integration/IndividualLandmarkSiteServiceTest.cs
@@ -80,7 +80,7 @@ namespace MicroService.Test.Integration
 
         //[InlineData(987615.655217366, 211953.9590513381, "Hotel Martinique", "MN")]
         //[Theory(DisplayName = "Get Geospatial Point Lookup -NAD83")]
-        public void Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
+        void IShapeTest.Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
         {
             throw new NotImplementedException();
         }

--- a/test/MicroService.Test/Integration/NeighborhoodServiceTest.cs
+++ b/test/MicroService.Test/Integration/NeighborhoodServiceTest.cs
@@ -77,7 +77,7 @@ namespace MicroService.Test.Integration
             Assert.Equal(expected2, sut.NTACode);
         }
 
-        public void Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
+        void IShapeTest.Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
         {
             throw new NotImplementedException();
         }

--- a/test/MicroService.Test/Integration/NeighborhoodTabulationAreasTest.cs
+++ b/test/MicroService.Test/Integration/NeighborhoodTabulationAreasTest.cs
@@ -73,7 +73,7 @@ namespace MicroService.Test.Integration
             Assert.Equal(expected2, sut.CDTAName);
         }
 
-        public void Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
+        void IShapeTest.Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
         {
             throw new NotImplementedException();
         }

--- a/test/MicroService.Test/Integration/NychaDevelopmentTest.cs
+++ b/test/MicroService.Test/Integration/NychaDevelopmentTest.cs
@@ -76,7 +76,7 @@ namespace MicroService.Test.Integration
             Assert.Equal(expected2, sut.Development);
         }
 
-        public void Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
+        void IShapeTest.Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
         {
             throw new NotImplementedException();
         }

--- a/test/MicroService.Test/Integration/NypdPolicePrecinctServiceTest.cs
+++ b/test/MicroService.Test/Integration/NypdPolicePrecinctServiceTest.cs
@@ -65,8 +65,9 @@ namespace MicroService.Test.Integration
         [InlineData(1000443, 0239270, "32", 0)]
         [InlineData(1021192.9426658918, 212550.01741990919, "115", 0)]
         [Theory(DisplayName = "Get Geospatial Point Lookup")]
-        public void Get_Geospatial_Point_Lookup(double x, double y, string expected, object lookupExpected)
+        public void Get_Geospatial_Point_Lookup(double x, double y, string expected, object _lookupExpected)
         {
+            _ = _lookupExpected; // Required by the shared shape-test contract.
             var sut = _service.GetFeatureLookup(x, y, Datum.Nad83);
 
             Assert.NotNull(sut);
@@ -75,8 +76,9 @@ namespace MicroService.Test.Integration
 
         [InlineData(-73.965624, 40.78268, "22", "22")]
         [Theory(DisplayName = "Get Geospatial Point Lookup - WGS84")]
-        public void Get_Geospatial_Point_Lookup_Wgs84(double x, double y, string expected, object expected2)
+        public void Get_Geospatial_Point_Lookup_Wgs84(double x, double y, string expected, object _expected2)
         {
+            _ = _expected2; // Required by the shared shape-test contract.
             var sut = _service.GetFeatureLookup(x, y, Datum.Wgs84);
 
             Assert.NotNull(sut);
@@ -85,8 +87,9 @@ namespace MicroService.Test.Integration
 
         [InlineData("14", "", "14")]
         [Theory(Skip = "TODO FIX - Not Filtering", DisplayName = "Get Feature Attribute Lookup")]
-        public void Get_Feature_Attribute_Lookup(object value1, object value2, string expected)
+        public void Get_Feature_Attribute_Lookup(object value1, object _value2, string expected)
         {
+            _ = _value2; // Required by the shared shape-test contract.
             // var value = Convert.ToDouble(value1);
             // var value = Convert.ToString(value1);
             var attributes = new List<KeyValuePair<string, object>>

--- a/test/MicroService.Test/Integration/SubwayServiceTest.cs
+++ b/test/MicroService.Test/Integration/SubwayServiceTest.cs
@@ -80,7 +80,7 @@ namespace MicroService.Test.Integration
             Assert.Equal(expected2, sut.Line);
         }
 
-        public void Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
+        void IShapeTest.Get_Geospatial_Point_Lookup_Wgs84(double latitude, double longitude, string expected, object expected2)
         {
             throw new NotImplementedException();
         }
@@ -96,8 +96,9 @@ namespace MicroService.Test.Integration
 
         [InlineData("Junction Boulevard & Roosevelt Avenue at NE corner", "", "1789")]
         [Theory(DisplayName = "Get Feature Attribute Lookup")]
-        public void Get_Feature_Attribute_Lookup(object value1, object value2, string expected)
+        public void Get_Feature_Attribute_Lookup(object value1, object _value2, string expected)
         {
+            _ = _value2; // Required by the shared shape-test contract.
             var attributes = new List<KeyValuePair<string, object>>
             {
                  new("Name", value1),


### PR DESCRIPTION
## Summary
- make intentionally unimplemented shared test-contract methods explicit interface implementations
- explicitly consume contract-only placeholder parameters without adding redundant assertions
- resolve five xUnit1013 and five xUnit1026 Sonar findings

## Validation
- `make check`
- `make build`
- verified no xUnit1013 or xUnit1026 analyzer warnings remain
- `make test` (226 passed, 12 skipped)
- top-stack `make sonar` confirms no remaining xUnit1013 or xUnit1026 findings

## Stack
- Middle of stack #476
- Targets `agent/sonar-attribute-usage` (#473)
- Followed by #475

## Risk
Low. Test discovery and production code are unchanged.