### PR TITLE
Simplify geometry coordinate transformations

### DIFF
--- a/src/MicroService.Service/Helpers/GeoTransformationHelper.cs
+++ b/src/MicroService.Service/Helpers/GeoTransformationHelper.cs
@@ -101,45 +101,37 @@ namespace MicroService.Service.Helpers
                 throw new ArgumentException("Invalid datum combination.");
             }
 
-            if (geometry is Point point)
+            switch (geometry)
             {
-                var xy = new[] { point.X, point.Y };
-                xy = wgs84ToNad83 ? ConvertWgs84ToNad83(xy) : ConvertNad83ToWgs84(xy);
-                point.X = xy[0];
-                point.Y = xy[1];
-            }
-            else if (geometry is LineString lineString)
-            {
-                for (int i = 0; i < lineString.Coordinates.Length; i++)
-                {
-                    var xy = new[] { lineString.Coordinates[i].X, lineString.Coordinates[i].Y };
-                    xy = wgs84ToNad83 ? ConvertWgs84ToNad83(xy) : ConvertNad83ToWgs84(xy);
-                    lineString.Coordinates[i].X = xy[0];
-                    lineString.Coordinates[i].Y = xy[1];
-                }
-            }
-            else if (geometry is Polygon polygon)
-            {
-                for (int i = 0; i < polygon.Shell.Coordinates.Length; i++)
-                {
-                    var xy = new[] { polygon.Shell.Coordinates[i].X, polygon.Shell.Coordinates[i].Y };
-                    xy = wgs84ToNad83 ? ConvertWgs84ToNad83(xy) : ConvertNad83ToWgs84(xy);
-                    polygon.Shell.Coordinates[i].X = xy[0];
-                    polygon.Shell.Coordinates[i].Y = xy[1];
-                }
-                for (int i = 0; i < polygon.Holes.Length; i++)
-                {
-                    for (int j = 0; j < polygon.Holes[i].Coordinates.Length; j++)
+                case Point point:
+                    TransformCoordinates(point.Coordinates, wgs84ToNad83);
+                    break;
+                case LineString lineString:
+                    TransformCoordinates(lineString.Coordinates, wgs84ToNad83);
+                    break;
+                case Polygon polygon:
+                    TransformCoordinates(polygon.Shell.Coordinates, wgs84ToNad83);
+                    foreach (var hole in polygon.Holes)
                     {
-                        var xy = new[] { polygon.Holes[i].Coordinates[j].X, polygon.Holes[i].Coordinates[j].Y };
-                        xy = wgs84ToNad83 ? ConvertWgs84ToNad83(xy) : ConvertNad83ToWgs84(xy);
-                        polygon.Holes[i].Coordinates[j].X = xy[0];
-                        polygon.Holes[i].Coordinates[j].Y = xy[1];
+                        TransformCoordinates(hole.Coordinates, wgs84ToNad83);
                     }
-                }
+                    break;
             }
 
             return geometry;
+        }
+
+        private static void TransformCoordinates(IEnumerable<Coordinate> coordinates, bool wgs84ToNad83)
+        {
+            foreach (var coordinate in coordinates)
+            {
+                var transformed = wgs84ToNad83
+                    ? ConvertWgs84ToNad83(new[] { coordinate.X, coordinate.Y })
+                    : ConvertNad83ToWgs84(new[] { coordinate.X, coordinate.Y });
+
+                coordinate.X = transformed[0];
+                coordinate.Y = transformed[1];
+            }
         }
 
     }

--- a/test/MicroService.Test/Unit/FunctionHelperUnitTest.cs
+++ b/test/MicroService.Test/Unit/FunctionHelperUnitTest.cs
@@ -139,6 +139,7 @@ namespace MicroService.Test.Unit
                 new Coordinate(90.12, 34.56),
                 new Coordinate(78.90, 12.34)
             });
+            var originalFirstCoordinate = lineString.Coordinates[0].Copy();
 
 
             // Act
@@ -150,6 +151,8 @@ namespace MicroService.Test.Unit
 
             var transformedLineString = (LineString)result;
             Assert.Equal(lineString.Coordinates.Length, transformedLineString.Coordinates.Length);
+            Assert.NotEqual(originalFirstCoordinate.X, transformedLineString.Coordinates[0].X);
+            Assert.NotEqual(originalFirstCoordinate.Y, transformedLineString.Coordinates[0].Y);
 
             for (int i = 0; i < lineString.Coordinates.Length; i++)
             {
@@ -180,6 +183,8 @@ namespace MicroService.Test.Unit
                 new Coordinate(34.56, 78.90)
             };
             var polygon = new Polygon(new LinearRing(exteriorRing), new[] { new LinearRing(interiorRing) });
+            var originalExteriorCoordinate = polygon.ExteriorRing.Coordinates[0].Copy();
+            var originalInteriorCoordinate = polygon.InteriorRings[0].Coordinates[0].Copy();
 
             // Act
             var result = GeoTransformationHelper.TransformGeometry(polygon, fromDatum, toDatum);
@@ -191,6 +196,10 @@ namespace MicroService.Test.Unit
             var transformedPolygon = (Polygon)result;
             Assert.Equal(exteriorRing.Length, transformedPolygon.ExteriorRing.Coordinates.Length);
             Assert.Equal(interiorRing.Length, transformedPolygon.InteriorRings[0].Coordinates.Length);
+            Assert.NotEqual(originalExteriorCoordinate.X, transformedPolygon.ExteriorRing.Coordinates[0].X);
+            Assert.NotEqual(originalExteriorCoordinate.Y, transformedPolygon.ExteriorRing.Coordinates[0].Y);
+            Assert.NotEqual(originalInteriorCoordinate.X, transformedPolygon.InteriorRings[0].Coordinates[0].X);
+            Assert.NotEqual(originalInteriorCoordinate.Y, transformedPolygon.InteriorRings[0].Coordinates[0].Y);
 
             //for (int i = 0; i < exteriorRing.Length; i++)
             //{


### PR DESCRIPTION
## Summary
- replace repeated geometry-specific coordinate loops with one transformation helper
- preserve Point, LineString, and Polygon behavior
- strengthen line and polygon regression assertions
- resolve the GeoTransformationHelper S3776 complexity finding

## Validation
- `make check`
- `make build`
- `make test` (226 passed, 12 skipped)
- `make sonar`; open findings reduced from 419 to 394 and all 25 targeted findings are absent

## Stack
- Top of stack #476
- Targets `agent/sonar-xunit-contracts` (#474)

## Risk
Low to moderate. The refactor is behavior-preserving and covered by point, line, and polygon tests.