### PR TITLE
Align shape service nullability contracts

### DIFF
--- a/src/MicroService.Service/Interfaces/IShapeService.cs
+++ b/src/MicroService.Service/Interfaces/IShapeService.cs
@@ -12,9 +12,9 @@ namespace MicroService.Service.Interfaces
 
         T GetFeatureLookup(double x, double y, Datum datum);
 
-        IEnumerable<T> GetFeatureLookup(List<KeyValuePair<string, object>> attributes);
+        IEnumerable<T> GetFeatureLookup(List<KeyValuePair<string, object>>? attributes);
 
-        FeatureCollection? GetFeatureCollection(List<KeyValuePair<string, object>>? attributes);
+        FeatureCollection? GetFeatureCollection(List<KeyValuePair<string, object>> attributes);
 
         IEnumerable<T> GetFeatureList();
 

--- a/src/MicroService.Service/Services/Base/AbstractShapeService.cs
+++ b/src/MicroService.Service/Services/Base/AbstractShapeService.cs
@@ -171,11 +171,11 @@ namespace MicroService.Service.Services.Base
             return results;
         }
 
-        public virtual IEnumerable<TShape>? GetFeatureLookup(List<KeyValuePair<string, object>>? attributes)
+        public virtual IEnumerable<TShape> GetFeatureLookup(List<KeyValuePair<string, object>>? attributes)
         {
             if (attributes == null)
             {
-                return null;
+                return Enumerable.Empty<TShape>();
             }
 
             attributes = ValidateFeatureKey(attributes);

--- a/src/MicroService.Service/Services/IndividualLandmarkHistoricDistrictsService.cs
+++ b/src/MicroService.Service/Services/IndividualLandmarkHistoricDistrictsService.cs
@@ -26,7 +26,7 @@ namespace MicroService.Service.Services
             _individualLandmarkSiteService = individualLandmarkSiteService;
         }
 
-        public override IEnumerable<IndividualLandmarkHistoricDistrictsShape>? GetFeatureLookup(List<KeyValuePair<string, object>>? attributes)
+        public override IEnumerable<IndividualLandmarkHistoricDistrictsShape> GetFeatureLookup(List<KeyValuePair<string, object>>? attributes)
         {
             attributes = MapLandmarkAttributes(attributes);
             return base.GetFeatureLookup(attributes);
@@ -61,6 +61,11 @@ namespace MicroService.Service.Services
 
         private List<KeyValuePair<string, object>>? MapLandmarkAttributes(List<KeyValuePair<string, object>>? attributes)
         {
+            if (attributes is null)
+            {
+                return null;
+            }
+
             if (attributes.Any(a => a.Key.Equals("LPNumber", StringComparison.InvariantCultureIgnoreCase)))
             {
                 var lpNumberValue = attributes.First(a => a.Key.Equals("LPNumber", StringComparison.InvariantCultureIgnoreCase)).Value.ToString();

--- a/test/MicroService.Test/Integration/IndividualLandmarkHistoricDistrictsTest.cs
+++ b/test/MicroService.Test/Integration/IndividualLandmarkHistoricDistrictsTest.cs
@@ -66,6 +66,14 @@ namespace MicroService.Test.Integration
             Assert.NotNull(features);
         }
 
+        [Fact]
+        public void GetFeatureLookup_ReturnsEmptySequenceForNullAttributes()
+        {
+            var result = _service.GetFeatureLookup(null);
+
+            Assert.Empty(result);
+        }
+
         [InlineData(-73.9600952918919, 40.63098618196636, "803 East 17th Street", "BK")]
         [Theory(DisplayName = "Get Geospatial Point Lookup")]
         public void Get_Geospatial_Point_Lookup(double x, double y, string expected, object expected2)

--- a/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
+++ b/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
@@ -40,6 +40,14 @@ namespace MicroService.Test.Unit
             Assert.Null(result);
         }
 
+        [Fact]
+        public void GetFeatureLookup_ReturnsEmptySequenceForNullAttributes()
+        {
+            var result = _service.GetFeatureLookup(null);
+
+            Assert.Empty(result);
+        }
+
         private sealed class TestShapeService : AbstractShapeService<BoroughBoundaryShape, BoroughBoundaryShapeProfile>
         {
             public TestShapeService()


### PR DESCRIPTION
## Summary

- align shape-service interface nullability with implementation behavior
- return an empty sequence when lookup attributes are null
- guard the landmark-specific override before attribute remapping
- add regression coverage for both base and landmark service null input

## Impact

This removes contradictory nullable contracts without changing valid-request behavior. Null lookup input is handled safely as an empty result instead of propagating null or throwing.

## Validation

- `make check`
- `make build`
- `make test` — 228 passed, 12 skipped
- Sonar: CS8766 and CS8767 reduced to zero

## Stack

Bottom PR in stack #480. PR #478 depends on this change.