### PR TITLE
Use generic enum APIs

### DIFF
--- a/src/MicroService.Service/Helpers/EnumHelper.cs
+++ b/src/MicroService.Service/Helpers/EnumHelper.cs
@@ -74,7 +74,7 @@ namespace MicroService.Service.Helpers
 
         public static bool IsEnumValid<T>(string value) where T : struct, Enum
         {
-            return Enum.TryParse(value, out T result) && Enum.IsDefined(typeof(T), result);
+            return Enum.TryParse(value, out T result) && Enum.IsDefined(result);
         }
 
         public static List<PropertyInfo> GetPropertiesWithAttribute<TAttr>(Type type) where TAttr : Attribute

--- a/src/MicroService.Service/Mappings/HistoricDistrictShapeProfile.cs
+++ b/src/MicroService.Service/Mappings/HistoricDistrictShapeProfile.cs
@@ -34,7 +34,7 @@ namespace MicroService.Service.Mappings
                         : Regex.Replace(src.Attributes["other_hear"].ToString(), @"\u0000", string.Empty)))
                 .ForMember(dest => dest.PublicHearing, opt => opt.MapFrom(src => src.Attributes["public_hea"].ToString()))
                 .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Attributes["status_of_"].ToString()))
-                .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src => (int)Enum.Parse(typeof(Borough), src.Attributes["borough"].ToString())))
+                .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src => (int)Enum.Parse<Borough>(src.Attributes["borough"].ToString()!)))
                 .ForMember(dest => dest.ShapeArea, opt => opt.MapFrom(src => double.Parse(src.Attributes["shape_area"].ToString())))
                 .ForMember(dest => dest.ShapeLength, opt => opt.MapFrom(src => double.Parse(src.Attributes["shape_leng"].ToString())))
                 .ForMember(dest => dest.Geometry, opt => opt.MapFrom(src => src.Geometry))

--- a/src/MicroService.Service/Mappings/IndividualLandmarkSiteShapeProfile.cs
+++ b/src/MicroService.Service/Mappings/IndividualLandmarkSiteShapeProfile.cs
@@ -15,9 +15,9 @@ namespace MicroService.Service.Mappings
             CreateMap<Feature, IndividualLandmarkSiteShape>()
                 .ForMember(dest => dest.LPNumber, opt => opt.MapFrom(src => src.Attributes["lpc_lpnumb"].ToString()))
                 .ForMember(dest => dest.AreaName, opt => opt.MapFrom(src => src.Attributes["lpc_name"].ToString()))
-                .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src => EnumHelper.IsEnumValid<Borough>(src.Attributes["borough"].ToString()) && src.Attributes["borough"] != null ?
-                    (int)Enum.Parse(typeof(Borough), src.Attributes["borough"].ToString()) : 0))
-                .ForMember(dest => dest.BoroName, opt => opt.MapFrom(src => EnumHelper.IsEnumValid<Borough>(src.Attributes["borough"].ToString()) && src.Attributes["borough"] != null ?
+                .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src => src.Attributes["borough"] != null && EnumHelper.IsEnumValid<Borough>(src.Attributes["borough"].ToString()) ?
+                    (int)Enum.Parse<Borough>(src.Attributes["borough"].ToString()!) : 0))
+                .ForMember(dest => dest.BoroName, opt => opt.MapFrom(src => src.Attributes["borough"] != null && EnumHelper.IsEnumValid<Borough>(src.Attributes["borough"].ToString()) ?
                     src.Attributes["borough"].ToString() : null))
                 .ForMember(dest => dest.BBL, opt => opt.MapFrom(src => src.Attributes["bbl"] != null ? Double.Parse(src.Attributes["bbl"].ToString()) : 0))
                 .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Attributes["address"].ToString()))

--- a/src/MicroService.Service/Mappings/NationalRegisterHistoricPlacesShapeProfile.cs
+++ b/src/MicroService.Service/Mappings/NationalRegisterHistoricPlacesShapeProfile.cs
@@ -17,9 +17,9 @@ namespace MicroService.Service.Mappings
                 .ForMember(dest => dest.Bbl, opt => opt.MapFrom(src => double.Parse(src.Attributes["bbl"].ToString())))
                 .ForMember(dest => dest.BoroName, opt => opt.MapFrom(src => src.Attributes["borough"].ToString()))
                 .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src =>
-                    EnumHelper.IsEnumValid<Borough>(src.Attributes["borough"].ToString()) &&
-                    src.Attributes["borough"] != null
-                        ? (int)Enum.Parse(typeof(Borough), src.Attributes["borough"].ToString())
+                    src.Attributes["borough"] != null &&
+                    EnumHelper.IsEnumValid<Borough>(src.Attributes["borough"].ToString())
+                        ? (int)Enum.Parse<Borough>(src.Attributes["borough"].ToString()!)
                         : 0))
                 .ForMember(dest => dest.LPNumber, opt => opt.MapFrom(src => src.Attributes["lpc_lpnumb"].ToString()))
                 .ForMember(dest => dest.AreaName, opt => opt.MapFrom(src => src.Attributes["lpc_name"].ToString()))

--- a/src/MicroService.Service/Mappings/ScenicLandmarkShapeProfile.cs
+++ b/src/MicroService.Service/Mappings/ScenicLandmarkShapeProfile.cs
@@ -14,7 +14,7 @@ namespace MicroService.Service.Mappings
                 .ForMember(dest => dest.LPNumber, opt => opt.MapFrom(src => src.Attributes["lp_number"].ToString()))
                 .ForMember(dest => dest.AreaName, opt => opt.MapFrom(src => src.Attributes["scen_lm_na"].ToString()))
                 .ForMember(dest => dest.BoroName, opt => opt.MapFrom(src => src.Attributes["borough"].ToString()))
-                .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src => (int)Enum.Parse(typeof(Borough), src.Attributes["borough"].ToString())))
+                .ForMember(dest => dest.BoroCode, opt => opt.MapFrom(src => (int)Enum.Parse<Borough>(src.Attributes["borough"].ToString()!)))
                 .ForMember(dest => dest.ShapeArea, opt => opt.MapFrom(src => double.Parse(src.Attributes["shape_area"].ToString())))
                 .ForMember(dest => dest.ShapeLength, opt => opt.MapFrom(src => double.Parse(src.Attributes["shape_leng"].ToString())))
                 .ForMember(dest => dest.Geometry, opt => opt.MapFrom(src => src.Geometry))

--- a/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
@@ -59,7 +59,7 @@ namespace MicroService.WebApi.V1.Controllers
                 fileName = j.GetAttribute<ShapeAttribute>().FileName,
                 directory = j.GetAttribute<ShapeAttribute>().Directory,
                 datum = j.GetAttribute<ShapeAttribute>().Datum.ToString(),
-            });
+            }).ToList();
 
             _logger.LogInformation("{@ShapeProperties}", result);
 
@@ -82,7 +82,7 @@ namespace MicroService.WebApi.V1.Controllers
         public ActionResult<object> GetShapeProperties(
             [FromRoute][EnumDataType(typeof(ShapeProperties))] ShapeProperties id)
         {
-            if (!Enum.IsDefined(typeof(ShapeProperties), id))
+            if (!Enum.IsDefined(id))
                 return BadRequest();
 
             var service = _shapeServiceResolver!(id.ToString());
@@ -126,7 +126,7 @@ namespace MicroService.WebApi.V1.Controllers
         [ProducesResponseType(404)]
         public async Task<ActionResult<object>> GetFeatureList([FromQuery] FeatureAttributeRequestModel request)
         {
-            if (string.IsNullOrEmpty(request?.Key.ToString()) || !Enum.IsDefined(typeof(ShapeProperties), request.Key))
+            if (request is null || !Enum.IsDefined(request.Key))
                 return BadRequest();
 
             IEnumerable<ShapeBase> results = _shapeServiceResolver!(request.Key.ToString()).GetFeatureList();
@@ -145,7 +145,7 @@ namespace MicroService.WebApi.V1.Controllers
         [ProducesResponseType(404)]
         public async Task<ActionResult<object>> GetGeospatialLookup([FromQuery] FeatureGeoRequestModel request)
         {
-            if (string.IsNullOrEmpty(request?.Type.ToString()) || !Enum.IsDefined(typeof(ShapeProperties), request.Type))
+            if (request is null || !Enum.IsDefined(request.Type))
                 return BadRequest();
 
             var validate = _shapeServiceResolver!(ShapeProperties.BoroughBoundaries.ToString()).GetFeatureLookup(request.X, request.Y, request.Datum);

--- a/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
+++ b/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
@@ -30,7 +30,7 @@ namespace MicroService.Test.Controllers
         public async Task GetFeatureList_WithValidRequest_ReturnsOkResult(string key, List<ShapeBase> expectedResults)
         {
             // Arrange
-            var request = new FeatureAttributeRequestModel { Key = (ShapeProperties)System.Enum.Parse(typeof(ShapeProperties), key) };
+            var request = new FeatureAttributeRequestModel { Key = System.Enum.Parse<ShapeProperties>(key) };
 
             var shapeServiceMock = new Mock<IShapeService<ShapeBase>>();
             shapeServiceMock.Setup(s => s.GetFeatureList()).Returns(expectedResults);
@@ -54,7 +54,7 @@ namespace MicroService.Test.Controllers
         public async Task GetFeatureList_WithInvalidRequest_ReturnsBadRequestResult(string key)
         {
             // Arrange
-            var request = new FeatureAttributeRequestModel { Key = (ShapeProperties)System.Enum.Parse(typeof(ShapeProperties), key) }; ;
+            var request = new FeatureAttributeRequestModel { Key = System.Enum.Parse<ShapeProperties>(key) };
 
             // Act
             var controller = GetFeatureServiceController();

--- a/test/MicroService.Test/Enum/ShapePropertiesTests.cs
+++ b/test/MicroService.Test/Enum/ShapePropertiesTests.cs
@@ -21,7 +21,7 @@ public class ShapePropertiesTests
     {
         var invalidEnumValues = new List<string>();
 
-        foreach (var enumValue in System.Enum.GetValues(typeof(ShapeProperties)).Cast<ShapeProperties>())
+        foreach (var enumValue in System.Enum.GetValues<ShapeProperties>())
         {
             var shapeAttribute = enumValue.GetType()
                 .GetMember(enumValue.ToString())[0]


### PR DESCRIPTION
## Summary

- replace reflection-based enum APIs with their generic .NET equivalents
- retain existing parsing behavior while making nullability intent explicit
- short-circuit nullable borough values before conversion
- remove a stray statement and a trailing space from a mapping filename

## Impact

This is a focused modernization that removes CA2263 findings while preserving enum validation and parsing behavior.

## Validation

- `make check`
- `make build`
- `make test` — 228 passed, 12 skipped
- Sonar: CA2263 reduced to zero with no new nullable warnings

## Stack

Middle PR in stack #480. Depends on PR #477; PR #479 depends on this change.