### PR TITLE
Add shared Roslyn analyzer workflow

### DIFF
--- a/.agents/skills/net-roslyn-code-analyzers/SKILL.md
+++ b/.agents/skills/net-roslyn-code-analyzers/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: net-roslyn-code-analyzers
+description: >-
+  Diagnose and remediate Roslyn compiler and analyzer findings in this .NET
+  solution. Use for C# warnings, CA/CS/IDE diagnostics, analyzer policy changes,
+  code-quality gates, or warning-focused cleanup work.
+---
+
+# Roslyn Analyzer Workflow
+
+## Repository Context
+
+- Solution: MicroService.sln
+- Build commands:
+  - make check
+  - make analyze
+  - make build
+  - make test
+  - make sonar
+- Shared build policy file: Directory.Build.props
+
+## Workflow
+
+1. Reproduce diagnostics with `make analyze` or `make sonar`.
+2. Classify diagnostics by scope:
+   - correctness or security
+   - maintainability or style
+   - performance
+3. Confirm the affected behavior and add regression coverage when appropriate.
+4. Fix the root cause without unrelated refactoring or broad suppression.
+5. Run `make check`, `make analyze`, and `make test`.
+6. Run `make sonar` when SonarQube findings or metrics are in scope.
+7. Report rule-count changes and any intentionally deferred findings.
+
+## Common Actions
+
+- Correct API misuse and nullability warnings.
+- Address style and readability diagnostics without broad rewrites.
+- Tighten or relax rule severity only with explicit justification.
+- Keep behavior stable while fixing analyzer findings.
+- Keep each pull request focused on a small, independently validated rule set.
+
+## Non-Goals
+
+- Do not perform unrelated refactors while resolving analyzer diagnostics.
+- Do not weaken rules globally unless explicitly requested.
+- Do not add null-forgiving operators or suppressions without proving the value
+  is safe at that boundary.
+
+## References
+
+- https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options
+- https://learn.microsoft.com/dotnet/fundamentals/code-analysis/code-style-rule-options

--- a/.agents/skills/net-roslyn-code-analyzers/SKILL.md
+++ b/.agents/skills/net-roslyn-code-analyzers/SKILL.md
@@ -1,53 +1,52 @@
 ---
 name: net-roslyn-code-analyzers
-description: >-
-  Diagnose and remediate Roslyn compiler and analyzer findings in this .NET
-  solution. Use for C# warnings, CA/CS/IDE diagnostics, analyzer policy changes,
-  code-quality gates, or warning-focused cleanup work.
+description: Diagnose, configure, and remediate .NET Roslyn analyzer diagnostics in this repository. Use for C# compiler or analyzer warnings, CA/IDE/S/SA/RCS diagnostic codes, static-analysis failures, code-quality gates, .editorconfig severity changes, or requests to run and interpret the repository's analyzer workflow. Do not use for ordinary feature work without analyzer findings.
 ---
 
-# Roslyn Analyzer Workflow
+# .NET Roslyn Code Analyzers
 
-## Repository Context
-
-- Solution: MicroService.sln
-- Build commands:
-  - make check
-  - make analyze
-  - make build
-  - make test
-  - make sonar
-- Shared build policy file: Directory.Build.props
+Apply analyzer changes incrementally while preserving application behavior.
 
 ## Workflow
 
-1. Reproduce diagnostics with `make analyze` or `make sonar`.
-2. Classify diagnostics by scope:
-   - correctness or security
-   - maintainability or style
-   - performance
-3. Confirm the affected behavior and add regression coverage when appropriate.
-4. Fix the root cause without unrelated refactoring or broad suppression.
-5. Run `make check`, `make analyze`, and `make test`.
-6. Run `make sonar` when SonarQube findings or metrics are in scope.
-7. Report rule-count changes and any intentionally deferred findings.
+1. Read `Makefile`, `Directory.Build.props`, relevant project files, and any
+   `.editorconfig` before changing analyzer configuration.
+2. Reproduce the finding with the narrowest applicable command:
+   - `dotnet build <project> --no-restore` for a single project.
+   - `make analyze` for a solution-wide analyzer build.
+   - `make sonar` only when SonarQube credentials and server access are
+     available and the user requests server analysis.
+3. Record each diagnostic ID, severity, file, and line. Do not infer a rule from
+   message text when an ID is available.
+4. Classify the finding before editing. Read
+   [diagnostic-routing.md](references/diagnostic-routing.md) for routing and
+   remediation priorities.
+5. Fix correctness, security, reliability, and performance findings before
+   maintainability or style findings. Keep each change focused.
+6. Prefer correcting code. Change severity or suppress a diagnostic only when
+   the rule is inapplicable, generated code is involved, or compatibility
+   requires it. Use the narrowest suppression and document why.
+7. Run formatting only on touched files. Avoid broad analyzer-driven rewrites.
+8. Validate changes with `make check`, `make analyze`, `make build`, and
+   `make test` so the PR has evidence matching the named CI checks.
+9. Report fixed diagnostic IDs, intentional suppressions, commands run, and any
+   remaining findings.
 
-## Common Actions
+## Analyzer policy
 
-- Correct API misuse and nullability warnings.
-- Address style and readability diagnostics without broad rewrites.
-- Tighten or relax rule severity only with explicit justification.
-- Keep behavior stable while fixing analyzer findings.
-- Keep each pull request focused on a small, independently validated rule set.
+- Treat existing SDK analyzers and configured Sonar analysis as the current
+  baseline.
+- Do not add Roslynator, StyleCop, SonarAnalyzer, or another analyzer package
+  without checking overlap, expected warning volume, maintenance status, and
+  CI impact.
+- Introduce a new analyzer suite in its own focused PR with an explicit baseline
+  and staged severity policy.
+- Keep build and local behavior aligned; do not create an agent-only quality
+  gate that contributors or CI cannot reproduce.
 
-## Non-Goals
+## Boundaries
 
-- Do not perform unrelated refactors while resolving analyzer diagnostics.
-- Do not weaken rules globally unless explicitly requested.
-- Do not add null-forgiving operators or suppressions without proving the value
-  is safe at that boundary.
-
-## References
-
-- https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options
-- https://learn.microsoft.com/dotnet/fundamentals/code-analysis/code-style-rule-options
+- Do not weaken rules globally merely to obtain a clean build.
+- Do not mix unrelated refactoring or package upgrades into a diagnostic fix.
+- Never run `make sonar` without the required local credentials.
+- Do not expose `.env`, Sonar tokens, or scanner-generated output.

--- a/.agents/skills/net-roslyn-code-analyzers/agents/openai.yaml
+++ b/.agents/skills/net-roslyn-code-analyzers/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Roslyn Analyzer Cleanup"
+  display_name: ".NET Roslyn Code Analyzers"
   short_description: "Diagnose and fix .NET analyzer findings"
-  default_prompt: "Use $net-roslyn-code-analyzers to diagnose and remediate the reported C# analyzer findings."
+  default_prompt: "Use $net-roslyn-code-analyzers to diagnose and resolve analyzer findings in this .NET solution."

--- a/.agents/skills/net-roslyn-code-analyzers/agents/openai.yaml
+++ b/.agents/skills/net-roslyn-code-analyzers/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roslyn Analyzer Cleanup"
+  short_description: "Diagnose and fix .NET analyzer findings"
+  default_prompt: "Use $net-roslyn-code-analyzers to diagnose and remediate the reported C# analyzer findings."

--- a/.agents/skills/net-roslyn-code-analyzers/references/diagnostic-routing.md
+++ b/.agents/skills/net-roslyn-code-analyzers/references/diagnostic-routing.md
@@ -1,0 +1,34 @@
+# Diagnostic routing
+
+Use the diagnostic prefix and rule documentation to choose the remediation
+path. Confirm unfamiliar rules in the analyzer owner's official documentation.
+
+| Prefix | Typical source | First action |
+| --- | --- | --- |
+| `CS` | C# compiler | Fix correctness or language semantics before analyzer work. |
+| `CA` | .NET SDK analyzers | Check correctness, security, reliability, and performance impact. |
+| `IDE` | .NET code style | Confirm repository style policy before changing severity. |
+| `S` | Sonar analyzer/server | Confirm the issue and quality profile in SonarQube. |
+| `SA` | StyleCop | Check style configuration and avoid documentation churn. |
+| `RCS` | Roslynator | Confirm that Roslynator is installed before applying its guidance. |
+
+## Priority
+
+1. Correctness and security
+2. Reliability and resource lifetime
+3. Performance
+4. Maintainability
+5. Naming, layout, and documentation style
+
+## Suppression decision
+
+Suppress only when at least one condition is true:
+
+- The analyzer cannot understand a valid framework or generated-code pattern.
+- A public compatibility contract prevents the recommended change.
+- The finding is a documented false positive.
+- A broader fix belongs to a separately tracked change and the temporary
+  suppression has an owner and explanation.
+
+Prefer, in order: a code fix, a scoped source suppression with justification, a
+project-specific severity entry, then a repository-wide policy change.

--- a/.claude/skills/net-roslyn-code-analyzers/SKILL.md
+++ b/.claude/skills/net-roslyn-code-analyzers/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: net-roslyn-code-analyzers
+description: Diagnose, configure, and remediate .NET Roslyn analyzer diagnostics in this repository. Use for compiler or analyzer warnings, diagnostic codes, static-analysis failures, code-quality gates, and analyzer policy changes.
+---
+
+# .NET Roslyn Code Analyzers
+
+Read and follow the canonical project skill at
+`../../../.agents/skills/net-roslyn-code-analyzers/SKILL.md`.
+
+Resolve all relative resource links from the canonical skill directory.

--- a/.github/instructions/net-roslyn-code-analyzers.instructions.md
+++ b/.github/instructions/net-roslyn-code-analyzers.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "src/**/*.cs,test/**/*.cs,**/*.csproj,Directory.Build.props,.editorconfig"
+---
+
+# .NET Roslyn Code Analyzers
+
+When a request is related to C# warnings, analyzer diagnostics, code quality
+policy, linting, or rule remediation:
+
+1. Use the shared project skill in
+   `.agents/skills/net-roslyn-code-analyzers/SKILL.md`.
+2. Prefer repository commands for validation:
+   - `make check`
+   - `make analyze`
+   - `make test`
+   - `make sonar` when SonarQube findings are in scope
+3. Keep analyzer fixes scoped to the reported diagnostics and avoid unrelated
+   refactors.
+4. If analyzer severity changes are needed, update policy intentionally and
+   explain impact on CI and local development.

--- a/.github/instructions/net-roslyn-code-analyzers.instructions.md
+++ b/.github/instructions/net-roslyn-code-analyzers.instructions.md
@@ -7,14 +7,6 @@ applyTo: "src/**/*.cs,test/**/*.cs,**/*.csproj,Directory.Build.props,.editorconf
 When a request is related to C# warnings, analyzer diagnostics, code quality
 policy, linting, or rule remediation:
 
-1. Use the shared project skill in
+1. Read and follow the canonical project skill at
    `.agents/skills/net-roslyn-code-analyzers/SKILL.md`.
-2. Prefer repository commands for validation:
-   - `make check`
-   - `make analyze`
-   - `make test`
-   - `make sonar` when SonarQube findings are in scope
-3. Keep analyzer fixes scoped to the reported diagnostics and avoid unrelated
-   refactors.
-4. If analyzer severity changes are needed, update policy intentionally and
-   explain impact on CI and local development.
+2. Resolve its relative resource links from the canonical skill directory.

--- a/.github/instructions/pull-requests.instructions.md
+++ b/.github/instructions/pull-requests.instructions.md
@@ -30,6 +30,8 @@ These rules apply to every change proposed to this repository.
 
 Use GitHub stacked pull requests when work depends on an unmerged change:
 
+Reference: https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests
+
 1. The bottom PR targets `master`.
 2. Each higher PR targets the head branch of the PR immediately below it.
 3. Each layer must contain one focused change and pass validation independently.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,21 @@ jobs:
       - name: Build solution
         run: dotnet build MicroService.sln --configuration Release --no-restore
 
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: Run analyzer validation
+        run: make analyze
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,21 @@ under `.github/instructions/`.
 - Restore and build: `make build`
 - Test: `make test`
 - Run all local checks: `make check`
+- Run analyzer validation: `make analyze`
 - Run pre-commit directly: `pre-commit run --all-files`
+
+## Local AI Skills
+
+This repository keeps shared project-local skills under `.agents/skills/`.
+
+- Roslyn skill: `.agents/skills/net-roslyn-code-analyzers/SKILL.md`
 
 ## Pull Request Workflow
 
 Follow `.github/instructions/pull-requests.instructions.md` for every pull
 request. In particular:
+
+- Stacked PR reference: `https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests`
 
 - Never commit directly to `master`.
 - Create focused branches and pull requests that are ready for review, not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,14 @@ under `.github/instructions/`.
 - Run analyzer validation: `make analyze`
 - Run pre-commit directly: `pre-commit run --all-files`
 
-## Local AI Skills
+## Project Skills
 
-This repository keeps shared project-local skills under `.agents/skills/`.
-
-- Roslyn skill: `.agents/skills/net-roslyn-code-analyzers/SKILL.md`
+- For C# compiler warnings, analyzer diagnostics, static analysis, or analyzer
+  policy, use the canonical project skill at
+  `.agents/skills/net-roslyn-code-analyzers/SKILL.md`.
+- Claude Code discovers the adapter under `.claude/skills/`; Codex discovers
+  the canonical skill under `.agents/skills/`; GitHub Copilot follows the
+  matching instruction under `.github/instructions/`.
 
 ## Pull Request Workflow
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <NuGetAudit>true</NuGetAudit>
     <NuGetAuditMode>all</NuGetAuditMode>
-    <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904;CA1873;CA2263;CS8766;CS8767</WarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,20 @@ TEST_PROJECT := test/MicroService.Test/MicroService.Test.csproj
 CONFIGURATION ?= Debug
 DOTNET ?= dotnet
 PRE_COMMIT ?= $(HOME)/.local/share/MicroService/pre-commit/bin/pre-commit
+RUN_ANALYZERS ?= 0
+ANALYZE_CONFIGURATION ?= Release
 
 .DEFAULT_GOAL := help
 
-.PHONY: help setup hooks check restore build run test sonar certificates
+.PHONY: help setup hooks check analyze restore build run test sonar certificates
 
 help:
 	@echo "Available targets:"
 	@echo "  make setup    Install .NET 10 and essential development tools"
 	@echo "  make hooks    Install the pre-commit Git hook"
 	@echo "  make check    Run pre-commit checks against all tracked files"
+	@echo "                Set RUN_ANALYZERS=1 to also run analyzer validation"
+	@echo "  make analyze  Build with Roslyn analyzers and code-style checks enabled"
 	@echo "  make restore  Restore NuGet packages"
 	@echo "  make build    Build the solution"
 	@echo "  make run      Run the Web API locally"
@@ -23,6 +27,8 @@ help:
 	@echo ""
 	@echo "Options:"
 	@echo "  CONFIGURATION=Debug|Release (default: Debug)"
+	@echo "  RUN_ANALYZERS=0|1 (default: 0)"
+	@echo "  ANALYZE_CONFIGURATION=Debug|Release (default: Release)"
 
 setup:
 	./scripts/setup.sh
@@ -32,6 +38,12 @@ hooks:
 
 check:
 	$(PRE_COMMIT) run --all-files
+	@if [ "$(RUN_ANALYZERS)" = "1" ]; then \
+		$(MAKE) analyze ANALYZE_CONFIGURATION=$(ANALYZE_CONFIGURATION) DOTNET=$(DOTNET); \
+	fi
+
+analyze: restore
+	$(DOTNET) build $(SOLUTION) --configuration $(ANALYZE_CONFIGURATION) --no-restore /p:RunAnalyzers=true /p:EnforceCodeStyleInBuild=true /p:ContinuousIntegrationBuild=true
 
 restore:
 	$(DOTNET) restore $(SOLUTION)

--- a/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -105,7 +105,7 @@ namespace MicroService.WebApi.Extensions
                 c.MapType<ShapeProperties>(() => new OpenApiSchema
                 {
                     Type = JsonSchemaType.String,
-                    Enum = Enum.GetNames(typeof(ShapeProperties))
+                    Enum = Enum.GetNames<ShapeProperties>()
                         .Select(name => JsonValue.Create(name))
                         .Cast<JsonNode>()
                         .ToList(),


### PR DESCRIPTION
## Summary

- keep one canonical Roslyn skill under the standard `.agents/skills` repository location
- add a lightweight `.claude/skills` discovery adapter that delegates to the canonical skill
- route GitHub Copilot and `AGENTS.md` to the same canonical workflow
- add diagnostic-family routing and explicit suppression safeguards
- add `make analyze` and optional `RUN_ANALYZERS=1 make check` support
- enforce the resolved CA1873, CA2263, CS8766, and CS8767 rules as build errors
- add a dedicated Analyze job to GitHub Actions
- modernize the final remaining `Enum.GetNames` CA2263 call
- reference GitHub stacked pull request documentation from project rules

## Why

The repository now exposes one substantive analyzer-remediation workflow to Codex, Claude Code, and GitHub Copilot without maintaining duplicate skill content or copying files during setup. Analyzer validation is reproducible locally and in CI.

## Validation

- canonical and Claude adapter skill validation — passed
- independent skill discovery/workflow test — passed
- `make check` — passed
- `make analyze` — passed with 259 existing warnings and 0 errors
- `make build` — passed with 259 existing warnings and 0 errors
- `make test` — 228 passed, 12 skipped

## Scope

The skill documents the current SDK analyzer and SonarQube baseline. Adding Roslynator, StyleCop, or another analyzer suite remains a separate focused change because each can introduce a substantial warning and policy surface.

## Risk

Low. Runtime behavior is unchanged. Builds will fail if CA1873, CA2263, CS8766, or CS8767 regress.