### PR TITLE
Initialize non-nullable model properties to eliminate CS8618

### DIFF
--- a/src/MicroService.Service/Models/Base/ShapeBase.cs
+++ b/src/MicroService.Service/Models/Base/ShapeBase.cs
@@ -12,15 +12,15 @@ namespace MicroService.Service.Models.Base
         public double ShapeLength { get; set; }
 
         [FeatureCollectionExclude]
-        public BoundingBox BoundingBox { get; set; }
+        public BoundingBox BoundingBox { get; set; } = null!;
 
         [FeatureCollectionExclude]
         [JsonIgnore]
-        public Geometry Geometry { get; set; }
+        public Geometry Geometry { get; set; } = null!;
 
         [FeatureCollectionExclude]
         [JsonIgnore]
-        public FeatureCollection Feature { get; set; }
+        public FeatureCollection Feature { get; set; } = null!;
 
     }
 
@@ -28,7 +28,7 @@ namespace MicroService.Service.Models.Base
     {
         public double Area { get; set; }
 
-        public CentrePoint Centre { get; set; }
+        public CentrePoint Centre { get; set; } = null!;
 
         public double Diameter { get; set; }
 

--- a/src/MicroService.Service/Models/BoroughBoundaryShape.cs
+++ b/src/MicroService.Service/Models/BoroughBoundaryShape.cs
@@ -11,6 +11,6 @@ namespace MicroService.Service.Models
         public int BoroCode { get; set; }
 
         [FeatureName("BoroName")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/CommunityDistrictShape.cs
+++ b/src/MicroService.Service/Models/CommunityDistrictShape.cs
@@ -14,9 +14,9 @@ namespace MicroService.Service.Models
 
         public int BoroCode { get; set; }
 
-        public string Borough { get; set; }
+        public string Borough { get; set; } = string.Empty;
 
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
     }
 }

--- a/src/MicroService.Service/Models/DSNYDistrictsShape.cs
+++ b/src/MicroService.Service/Models/DSNYDistrictsShape.cs
@@ -8,20 +8,20 @@ namespace MicroService.Service.Models
     public class DsnyDistrictsShape : ShapeBase
     {
         [FeatureName("district")]
-        public string District { get; set; }
+        public string District { get; set; } = string.Empty;
 
         [FeatureName("districtco")]
         public int DistrictCode { get; set; }
 
         [FeatureName("fid")]
-        public string Fid { get; set; }
+        public string Fid { get; set; } = string.Empty;
 
         [FeatureName("globalid")]
-        public string GlobalId { get; set; }
+        public string GlobalId { get; set; } = string.Empty;
 
-        public string OperationZone { get; set; }
+        public string OperationZone { get; set; } = string.Empty;
 
 
-        public string OperationZoneName { get; set; }
+        public string OperationZoneName { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/Enum/Attributes/FeatureAttribute.cs
+++ b/src/MicroService.Service/Models/Enum/Attributes/FeatureAttribute.cs
@@ -16,13 +16,13 @@ namespace MicroService.Service.Models.Enum.Attributes
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FeatureCollectionAttribute : Attribute
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class FeatureCollectionExcludeAttribute : Attribute
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/src/MicroService.Service/Models/FlatFileModels/StationComplexFlatFile.cs
+++ b/src/MicroService.Service/Models/FlatFileModels/StationComplexFlatFile.cs
@@ -6,6 +6,6 @@ namespace MicroService.Service.Models.FlatFileModels
     {
         public int ComplexId { get; set; }
 
-        public string ComplexName { get; set; }
+        public string ComplexName { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/FlatFileModels/StationFlatFile.cs
+++ b/src/MicroService.Service/Models/FlatFileModels/StationFlatFile.cs
@@ -8,31 +8,31 @@ namespace MicroService.Service.Models.FlatFileModels
 
         public int ComplexId { get; set; }
 
-        public string GtfsStopId { get; set; }
+        public string GtfsStopId { get; set; } = string.Empty;
 
-        public string Division { get; set; }
+        public string Division { get; set; } = string.Empty;
 
-        public string Line { get; set; }
+        public string Line { get; set; } = string.Empty;
 
-        public string StopName { get; set; }
+        public string StopName { get; set; } = string.Empty;
 
-        public string Borough { get; set; }
+        public string Borough { get; set; } = string.Empty;
 
-        public string DaytimeRoutes { get; set; }
+        public string DaytimeRoutes { get; set; } = string.Empty;
 
-        public string Structure { get; set; }
+        public string Structure { get; set; } = string.Empty;
 
         public double GTFSLatitude { get; set; }
         
         public double GTFSLongitude { get; set; }
 
-        public string NorthDirectionLabel { get; set; }
+        public string NorthDirectionLabel { get; set; } = string.Empty;
 
-        public string SouthDirectionLabel { get; set; }
+        public string SouthDirectionLabel { get; set; } = string.Empty;
 
         public bool ADA { get; set; }
         
-        public string ADANotes { get; set; }
+        public string ADANotes { get; set; } = string.Empty;
 
     }
 }

--- a/src/MicroService.Service/Models/HistoricDistrictShape.cs
+++ b/src/MicroService.Service/Models/HistoricDistrictShape.cs
@@ -8,41 +8,41 @@ namespace MicroService.Service.Models
     public class HistoricDistrictShape : ShapeBase, ILandmark
     {
         [FeatureName("lp_number")]
-        public string LPNumber { get; set; }
+        public string LPNumber { get; set; } = string.Empty;
 
         [FeatureName("area_name")]
-        public string AreaName { get; set; }
+        public string AreaName { get; set; } = string.Empty;
 
         [FeatureName("borough")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         public int BoroCode { get; set; }
 
         [FeatureName("boundary_n")]
-        public string BoundaryName { get; set; }
+        public string BoundaryName { get; set; } = string.Empty;
 
         [FeatureName("caldate")]
-        public string CalendarDate { get; set; }
+        public string CalendarDate { get; set; } = string.Empty;
 
         [FeatureName("current_")]
-        public string Current { get; set; }
+        public string Current { get; set; } = string.Empty;
 
         [FeatureName("desdate")]
-        public string DesignationDate { get; set; }
+        public string DesignationDate { get; set; } = string.Empty;
 
         [FeatureName("extension")]
-        public string Extension { get; set; }
+        public string Extension { get; set; } = string.Empty;
 
         [FeatureName("last_actio")]
-        public string LastAction { get; set; }
+        public string LastAction { get; set; } = string.Empty;
 
         [FeatureName("other_hear")]
-        public string OtherHearing { get; set; }
+        public string OtherHearing { get; set; } = string.Empty;
 
         [FeatureName("public_hea")]
-        public string PublicHearing { get; set; }
+        public string PublicHearing { get; set; } = string.Empty;
 
         [FeatureName("status_of_")]
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/IndividualLandmarkHistoricDistrictsShape.cs
+++ b/src/MicroService.Service/Models/IndividualLandmarkHistoricDistrictsShape.cs
@@ -11,10 +11,10 @@ namespace MicroService.Service.Models
         public double Bin { get; set; }
 
         [FeatureName("bbl")]
-        public string Bbl { get; set; }
+        public string Bbl { get; set; } = string.Empty;
 
         [FeatureName("borough")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         public int BoroCode { get; set; }
 
@@ -25,7 +25,7 @@ namespace MicroService.Service.Models
         public double Lot { get; set; }
 
         [FeatureName("des_addres")]
-        public string Address { get; set; }
+        public string Address { get; set; } = string.Empty;
 
         [FeatureName("circa")]
         public int Circa { get; set; }
@@ -37,79 +37,79 @@ namespace MicroService.Service.Models
         public int DateHigh { get; set; }
 
         [FeatureName("date_combo")]
-        public string DateCombo { get; set; }
+        public string DateCombo { get; set; } = string.Empty;
 
         [FeatureName("alt_date_1")]
-        public string AltDate1 { get; set; }
+        public string AltDate1 { get; set; } = string.Empty;
 
         [FeatureName("alt_date_2")]
-        public string AltDate2 { get; set; }
+        public string AltDate2 { get; set; } = string.Empty;
 
         [FeatureName("arch_build")]
-        public string ArchBuild { get; set; }
+        public string ArchBuild { get; set; } = string.Empty;
 
         [FeatureName("own_devel")]
-        public string OwnDevel { get; set; }
+        public string OwnDevel { get; set; } = string.Empty;
 
         [FeatureName("alt_arch_1")]
-        public string AltArch1 { get; set; }
+        public string AltArch1 { get; set; } = string.Empty;
 
         [FeatureName("alt_arch_2")]
-        public string AltArch2 { get; set; }
+        public string AltArch2 { get; set; } = string.Empty;
 
         [FeatureName("altered")]
         public int Altered { get; set; }
 
         [FeatureName("style_prim")]
-        public string StylePrim { get; set; }
+        public string StylePrim { get; set; } = string.Empty;
 
         [FeatureName("style_sec")]
-        public string StyleSec { get; set; }
+        public string StyleSec { get; set; } = string.Empty;
 
         [FeatureName("style_oth")]
-        public string StyleOth { get; set; }
+        public string StyleOth { get; set; } = string.Empty;
 
         [FeatureName("mat_prim")]
-        public string MatPrim { get; set; }
+        public string MatPrim { get; set; } = string.Empty;
 
         [FeatureName("mat_sec")]
-        public string MatSec { get; set; }
+        public string MatSec { get; set; } = string.Empty;
 
         [FeatureName("mat_third")]
-        public string MatThird { get; set; }
+        public string MatThird { get; set; } = string.Empty;
 
         [FeatureName("mat_four")]
-        public string MatFour { get; set; }
+        public string MatFour { get; set; } = string.Empty;
 
         [FeatureName("mat_other")]
-        public string MatOther { get; set; }
+        public string MatOther { get; set; } = string.Empty;
 
         [FeatureName("use_orig")]
-        public string UseOrig { get; set; }
+        public string UseOrig { get; set; } = string.Empty;
 
         [FeatureName("use_other")]
-        public string UseOther { get; set; }
+        public string UseOther { get; set; } = string.Empty;
 
         [FeatureName("build_type")]
-        public string BuildType { get; set; }
+        public string BuildType { get; set; } = string.Empty;
 
         [FeatureName("build_oth")]
-        public string BuildOth { get; set; }
+        public string BuildOth { get; set; } = string.Empty;
 
         [FeatureName("build_nme")]
-        public string BuildNme { get; set; }
+        public string BuildNme { get; set; } = string.Empty;
 
         [FeatureName("notes")]
-        public string Notes { get; set; }
+        public string Notes { get; set; } = string.Empty;
 
         [FeatureName("hist_dist")]
-        public string HistDist { get; set; }
+        public string HistDist { get; set; } = string.Empty;
 
         [FeatureName("lm_new")]
-        public string LmNew { get; set; }
+        public string LmNew { get; set; } = string.Empty;
 
         [FeatureName("lm_orig")]
-        public string AreaName { get; set; }
+        public string AreaName { get; set; } = string.Empty;
 
         //[FeatureName("SC_Flag")]
         //public int ScFlag { get; set; }
@@ -118,6 +118,6 @@ namespace MicroService.Service.Models
         //public int BblInt { get; set; }
 
         [MappingKeyAttribute("LPNumber")]
-        public string LPNumber { get; set; }
+        public string LPNumber { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/IndividualLandmarkSiteShape.cs
+++ b/src/MicroService.Service/Models/IndividualLandmarkSiteShape.cs
@@ -13,22 +13,22 @@ namespace MicroService.Service.Models
         public double ObjectId { get; set; }
 
         [FeatureName("lpc_lpnumb")]
-        public string LPNumber { get; set; }
+        public string LPNumber { get; set; } = string.Empty;
 
         [FeatureName("lpc_name")]
-        public string AreaName { get; set; }
+        public string AreaName { get; set; } = string.Empty;
 
         [FeatureName("lpc_altern")]
-        public string AlternativeName { get; set; }
+        public string AlternativeName { get; set; } = string.Empty;
 
         [FeatureName("bbl")]
         public double BBL { get; set; }
 
         [FeatureName("borough")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         [FeatureName("address")]
-        public string Address { get; set; }
+        public string Address { get; set; } = string.Empty;
 
         [FeatureName("block")]
         public double Block { get; set; }
@@ -37,19 +37,19 @@ namespace MicroService.Service.Models
         public double Lot { get; set; }
 
         [FeatureName("date_des_d")]
-        public string DesignationDate { get; set; }
+        public string DesignationDate { get; set; } = string.Empty;
 
         [FeatureName("url_report")]
-        public string UrlReport { get; set; }
+        public string UrlReport { get; set; } = string.Empty;
 
         [FeatureName("lpc_site_d")]
-        public string SiteDesignation { get; set; }
+        public string SiteDesignation { get; set; } = string.Empty;
 
         [FeatureName("lpc_site_s")]
-        public string DesignationStatus { get; set; }
+        public string DesignationStatus { get; set; } = string.Empty;
 
         [FeatureName("landmark_t")]
-        public string LandmarkType { get; set; }
+        public string LandmarkType { get; set; } = string.Empty;
 
 
 

--- a/src/MicroService.Service/Models/NationalRegisterHistoricPlacesShape.cs
+++ b/src/MicroService.Service/Models/NationalRegisterHistoricPlacesShape.cs
@@ -12,30 +12,30 @@ namespace MicroService.Service.Models
         public double ObjectId { get; set; }
 
         [FeatureName("address")]
-        public string Address { get; set; }
+        public string Address { get; set; } = string.Empty;
 
         [FeatureName("borough")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         public int BoroCode { get; set; }
 
         [FeatureName("lpc_lpnumb")]
-        public string LPNumber { get; set; }
+        public string LPNumber { get; set; } = string.Empty;
 
         [FeatureName("lpc_name")]
-        public string AreaName { get; set; }
+        public string AreaName { get; set; } = string.Empty;
 
         [FeatureName("lpc_altern")]
-        public string AlternativeName { get; set; }
+        public string AlternativeName { get; set; } = string.Empty;
 
         [FeatureName("lpc_site_d")]
-        public string SiteDesignation { get; set; }
+        public string SiteDesignation { get; set; } = string.Empty;
 
         [FeatureName("landmark_t")]
-        public string LandmarkType { get; set; }
+        public string LandmarkType { get; set; } = string.Empty;
 
         [FeatureName("lpc_site_s")]
-        public string DesignationStatus { get; set; }
+        public string DesignationStatus { get; set; } = string.Empty;
 
         [FeatureName("bbl")]
         public double Bbl { get; set; }
@@ -47,12 +47,12 @@ namespace MicroService.Service.Models
         public double Lot { get; set; }
 
         [FeatureName("url_report")]
-        public string UrlReport { get; set; }
+        public string UrlReport { get; set; } = string.Empty;
 
         [FeatureName("date_des_d")]
         public DateTime DateDesignated { get; set; }
 
         [FeatureName("time_des_d")]
-        public string TimeDesignated { get; set; }
+        public string TimeDesignated { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/NeighborhoodShape.cs
+++ b/src/MicroService.Service/Models/NeighborhoodShape.cs
@@ -11,15 +11,15 @@ namespace MicroService.Service.Models
         public int BoroCode { get; set; }
 
         [FeatureName("BoroName")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         [FeatureName("CountyFIPS")]
-        public string CountyFIPS { get; set; }
+        public string CountyFIPS { get; set; } = string.Empty;
 
         [FeatureName("NTACode")]
-        public string NTACode { get; set; }
+        public string NTACode { get; set; } = string.Empty;
 
         [FeatureName("NTAName")]
-        public string NTAName { get; set; }
+        public string NTAName { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/NeighborhoodTabulationAreaShape.cs
+++ b/src/MicroService.Service/Models/NeighborhoodTabulationAreaShape.cs
@@ -11,27 +11,27 @@ namespace MicroService.Service.Models
         public int BoroCode { get; set; }
 
         [FeatureName("BoroName")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         [FeatureName("CountyFIPS")]
-        public string CountyFIPS { get; set; }
+        public string CountyFIPS { get; set; } = string.Empty;
 
         [FeatureName("NTA2020")]
-        public string NTA2020 { get; set; }
+        public string NTA2020 { get; set; } = string.Empty;
 
         [FeatureName("NTAName")]
-        public string NTAName { get; set; }
+        public string NTAName { get; set; } = string.Empty;
 
         [FeatureName("NTAAbbrev")]
-        public string NTAAbbrev { get; set; }
+        public string NTAAbbrev { get; set; } = string.Empty;
 
         [FeatureName("NTAType")]
         public int NTAType { get; set; }
 
         [FeatureName("CDTA2020")]
-        public string CDTA2020 { get; set; }
+        public string CDTA2020 { get; set; } = string.Empty;
 
         [FeatureName("CDTAName")]
-        public string CDTAName { get; set; }
+        public string CDTAName { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/NychaDevelopmentShape.cs
+++ b/src/MicroService.Service/Models/NychaDevelopmentShape.cs
@@ -8,12 +8,12 @@ namespace MicroService.Service.Models
     public class NychaDevelopmentShape : ShapeBase
     {
         [FeatureName("DEVELOPMEN")]
-        public string Development { get; set; }
+        public string Development { get; set; } = string.Empty;
 
         [FeatureName("TDS_NUM")]
-        public string TdsNumber { get; set; }
+        public string TdsNumber { get; set; } = string.Empty;
 
         [FeatureName("BOROUGH")]
-        public string Borough { get; set; }
+        public string Borough { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/NypdSectorShape.cs
+++ b/src/MicroService.Service/Models/NypdSectorShape.cs
@@ -8,15 +8,15 @@ namespace MicroService.Service.Models
     public class NypdSectorShape : ShapeBase
     {
         [FeatureName("pct")]
-        public string Pct { get; set; }
+        public string Pct { get; set; } = string.Empty;
 
         [FeatureName("sector")]
-        public string Sector { get; set; }
+        public string Sector { get; set; } = string.Empty;
 
         [FeatureName("patrol_bor")]
-        public string PatrolBoro { get; set; }
+        public string PatrolBoro { get; set; } = string.Empty;
 
         [FeatureName("phase")]
-        public string Phase { get; set; }
+        public string Phase { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/ParkShape.cs
+++ b/src/MicroService.Service/Models/ParkShape.cs
@@ -8,10 +8,10 @@ namespace MicroService.Service.Models
     public class ParkShape : ShapeBase
     {
         [FeatureName("PARK_NAME")]
-        public string ParkName { get; set; }
+        public string ParkName { get; set; } = string.Empty;
 
         [FeatureName("PARKNUM")]
-        public string ParkNumber { get; set; }
+        public string ParkNumber { get; set; } = string.Empty;
 
         [FeatureName("SOURCE_ID")]
         public long SourceId { get; set; }
@@ -23,12 +23,12 @@ namespace MicroService.Service.Models
         public int SubCode { get; set; }
 
         [FeatureName("LANDUSE")]
-        public string LandUse { get; set; }
+        public string LandUse { get; set; } = string.Empty;
 
         [FeatureName("SYSTEM")]
-        public string System { get; set; }
+        public string System { get; set; } = string.Empty;
 
         [FeatureName("STATUS")]
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
     }
 }

--- a/src/MicroService.Service/Models/ScenicLandmarkShape.cs
+++ b/src/MicroService.Service/Models/ScenicLandmarkShape.cs
@@ -9,15 +9,15 @@ namespace MicroService.Service.Models
     {
         [FeatureCollection]
         [FeatureName("lp_number")]
-        public string LPNumber { get; set; }
+        public string LPNumber { get; set; } = string.Empty;
 
         [FeatureCollection]
         [FeatureName("scen_lm_na")]
-        public string AreaName { get; set; }
+        public string AreaName { get; set; } = string.Empty;
 
         [FeatureCollection]
         [FeatureName("borough")]
-        public string BoroName { get; set; }
+        public string BoroName { get; set; } = string.Empty;
 
         [FeatureCollection]
         public int BoroCode { get; set; }

--- a/src/MicroService.Service/Models/SubwayShape.cs
+++ b/src/MicroService.Service/Models/SubwayShape.cs
@@ -11,13 +11,13 @@ namespace MicroService.Service.Models
         public double ObjectId { get; set; }
 
         [FeatureName("line")]
-        public string Line { get; set; }
+        public string Line { get; set; } = string.Empty;
 
         [FeatureName("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         [FeatureName("url")]
-        public string Url { get; set; }
+        public string Url { get; set; } = string.Empty;
 
         public double Distance { get; set; }
     }

--- a/src/MicroService.Service/Models/ZipCodeShape.cs
+++ b/src/MicroService.Service/Models/ZipCodeShape.cs
@@ -8,13 +8,13 @@ namespace MicroService.Service.Models
     public class ZipCodeShape : ShapeBase
     {
         [FeatureName("ZIPCODE")]
-        public string ZipCode { get; set; }
+        public string ZipCode { get; set; } = string.Empty;
 
         [FeatureName("BLDGZIP")]
-        public string BldgZip { get; set; }
+        public string BldgZip { get; set; } = string.Empty;
 
         [FeatureName("PO_NAME")]
-        public string PostOfficeName { get; set; }
+        public string PostOfficeName { get; set; } = string.Empty;
 
         [FeatureName("POPULATION")]
         public int Population { get; set; }
@@ -23,19 +23,19 @@ namespace MicroService.Service.Models
         public double Area { get; set; }
 
         [FeatureName("STATE")]
-        public string State { get; set; }
+        public string State { get; set; } = string.Empty;
 
         [FeatureName("COUNTY")]
-        public string County { get; set; }
+        public string County { get; set; } = string.Empty;
 
         [FeatureName("ST_FIPS")]
-        public string StateFibs { get; set; }
+        public string StateFibs { get; set; } = string.Empty;
 
         [FeatureName("CTY_FIPS")]
-        public string CityFibs { get; set; }
+        public string CityFibs { get; set; } = string.Empty;
 
         [FeatureName("URL")]
-        public string Url { get; set; }
+        public string Url { get; set; } = string.Empty;
 
     }
 }


### PR DESCRIPTION
## Summary

- add `= string.Empty` defaults to non-nullable `string` auto-properties across `src/MicroService.Service/Models/**`
- add `= null!` to `ShapeBase`'s `BoundingBox`, `Geometry`, `Feature` and `BoundingBox.Centre`, which the shape-mapping pipeline always populates before use
- eliminates all 122 CS8618 warnings reported by the `Analyze` CI job under `Models/`

## Why

PR #481 added the `Analyze` CI job, which surfaced 199 nullable-reference warnings ([run](https://github.com/stuartshay/MicroService/actions/runs/30842167535/job/91781616509)). This is the first of a 3-PR stack working those down by area:

1. **This PR** — Model/DTO nullable annotations (123x CS8618)
2. Mapping profiles (~44x CS8604/CS8619) — stacked on this PR
3. Helpers & core services (~21 mixed warnings + 1 SYSLIB0012) — stacked on PR 2

Shape/DTO classes here are never constructed with a full set of arguments — they're populated entirely by AutoMapper profiles (`src/MicroService.Service/Mappings/**`) reading from shapefile/flat-file attributes, so the compiler can't statically prove non-nullable properties get assigned. `string.Empty` is used for plain string properties (safe, semantically correct default for reference-type DTO fields); `null!` is used only for complex reference types where a default constructor would imply misleadingly "valid" empty data (`Geometry`, `FeatureCollection`, `BoundingBox`, `CentrePoint`) and the mapping pipeline is the actual (unprovable) guarantor of non-null.

## Validation

- `make analyze` — CS8618 count in `Models/` goes from 122 to 0; no new warnings introduced (259 → 137 total, matching only the expected reduction)
- `make test` — 228 passed, 12 skipped (unchanged from baseline)
- `make check` — passed

## Risk

None — purely declarative nullable annotations/initializers, no logic changes.