### PR TITLE
Resolve nullable-reference warnings in helpers, services, and startup

### DIFF
--- a/src/MicroService.Data/Repository/TestDataRepository.cs
+++ b/src/MicroService.Data/Repository/TestDataRepository.cs
@@ -40,7 +40,8 @@ namespace MicroService.Data.Repository
             {
                 dbConnection.Open();
                 var result = await dbConnection.QueryAsync<TestData>("SELECT id, data FROM test_data WHERE id = @Id", new { Id = id });
-                return result.FirstOrDefault();
+                return result.FirstOrDefault()
+                    ?? throw new KeyNotFoundException($"TestData with id {id} was not found.");
             }
         }
 

--- a/src/MicroService.Service/Configuration/ShapeConfiguration.cs
+++ b/src/MicroService.Service/Configuration/ShapeConfiguration.cs
@@ -6,6 +6,8 @@
 
         public string? CronExpression { get; set; }
 
-        public string? ShapeSystemRootDirectory => Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ShapeRootDirectory));
+        public string? ShapeSystemRootDirectory => ShapeRootDirectory == null
+            ? null
+            : Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ShapeRootDirectory));
     }
 }

--- a/src/MicroService.Service/Helpers/CachedShapefileDataReader.cs
+++ b/src/MicroService.Service/Helpers/CachedShapefileDataReader.cs
@@ -36,6 +36,6 @@ namespace MicroService.Service.Helpers
                 cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(3);
 
                 return features;
-            });
+            }) ?? [];
     }
 }

--- a/src/MicroService.Service/Helpers/EnumHelper.cs
+++ b/src/MicroService.Service/Helpers/EnumHelper.cs
@@ -17,13 +17,21 @@ namespace MicroService.Service.Helpers
             where TAttribute : Attribute
         {
             var enumType = value.GetType();
-            var name = Enum.GetName(enumType, value);
-            return enumType.GetField(name).GetCustomAttributes(false).OfType<TAttribute>().SingleOrDefault();
+            var name = Enum.GetName(enumType, value)
+                ?? throw new ArgumentException($"'{value}' is not a defined member of {enumType}.", nameof(value));
+            var field = enumType.GetField(name)
+                ?? throw new ArgumentException($"Field '{name}' not found on {enumType}.", nameof(value));
+            return field.GetCustomAttributes(false).OfType<TAttribute>().SingleOrDefault()
+                ?? throw new ArgumentException($"'{value}' does not have attribute '{typeof(TAttribute)}'.", nameof(value));
         }
 
         public static string GetEnumDescription(this Enum value)
         {
-            FieldInfo fi = value.GetType().GetField(value.ToString());
+            var fi = value.GetType().GetField(value.ToString());
+            if (fi == null)
+            {
+                return value.ToString();
+            }
 
             var attributes = fi.GetCustomAttributes(typeof(DescriptionAttribute), false)
                 .OfType<DescriptionAttribute>();
@@ -39,13 +47,15 @@ namespace MicroService.Service.Helpers
             {
                 var attribute =
                     Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) as DescriptionAttribute;
+                // field.GetValue(null) reads a static enum field's boxed value, which is
+                // never null for an actual enum member.
                 if (attribute != null)
                 {
-                    if (attribute.Description == description) return (T)field.GetValue(null);
+                    if (attribute.Description == description) return (T)field.GetValue(null)!;
                 }
                 else
                 {
-                    if (field.Name == description) return (T)field.GetValue(null);
+                    if (field.Name == description) return (T)field.GetValue(null)!;
                 }
             }
 

--- a/src/MicroService.Service/Helpers/FileHelpers.cs
+++ b/src/MicroService.Service/Helpers/FileHelpers.cs
@@ -17,10 +17,9 @@ namespace MicroService.Service.Helpers
 
         private static string GetAssemblyDirectory()
         {
-            string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-            UriBuilder uri = new UriBuilder(codeBase);
-            string path = Uri.UnescapeDataString(uri.Path);
-            return Path.GetDirectoryName(path);
+            var location = Assembly.GetExecutingAssembly().Location;
+            return Path.GetDirectoryName(location)
+                ?? throw new InvalidOperationException("Unable to determine the executing assembly's directory.");
         }
 
     }

--- a/src/MicroService.Service/Helpers/ReflectionExtensions.cs
+++ b/src/MicroService.Service/Helpers/ReflectionExtensions.cs
@@ -21,10 +21,11 @@ namespace MicroService.Service.Helpers
             public static IReadOnlyCollection<PropertyInfo> PublicProperties => PropertyCache<T>.publicPropertiesLazy.Value;
         }
 
-        public static TAttribute GetAttributeFromProperty<TAttribute>(object obj, string propertyName) where TAttribute : Attribute
+        public static TAttribute? GetAttributeFromProperty<TAttribute>(object obj, string propertyName) where TAttribute : Attribute
         {
-            var property = obj.GetType().GetProperty(propertyName);
-            return property!.GetCustomAttribute<TAttribute>();
+            var property = obj.GetType().GetProperty(propertyName)
+                ?? throw new ArgumentException($"Property '{propertyName}' not found on {obj.GetType()}.", nameof(propertyName));
+            return property.GetCustomAttribute<TAttribute>();
         }
 
         public static PropertyInfo[] GetPropertiesWithCustomAttribute<T>(this Type type) where T : Attribute

--- a/src/MicroService.Service/Interfaces/IShapeService.cs
+++ b/src/MicroService.Service/Interfaces/IShapeService.cs
@@ -10,7 +10,7 @@ namespace MicroService.Service.Interfaces
     {
         IReadOnlyCollection<Feature> GetFeatures();
 
-        T GetFeatureLookup(double x, double y, Datum datum);
+        T? GetFeatureLookup(double x, double y, Datum datum);
 
         IEnumerable<T> GetFeatureLookup(List<KeyValuePair<string, object>>? attributes);
 

--- a/src/MicroService.Service/Services/Base/AbstractShapeService.cs
+++ b/src/MicroService.Service/Services/Base/AbstractShapeService.cs
@@ -15,7 +15,8 @@ namespace MicroService.Service.Services.Base
         where TShape : class, new()
         where TProfile : Profile, new()
     {
-        protected IShapefileDataReaderService ShapeFileDataReader { get; set; }
+        // Always assigned in each derived class's constructor via a ShapefileDataReaderResolver.
+        protected IShapefileDataReaderService ShapeFileDataReader { get; set; } = null!;
 
         protected readonly IMapper Mapper;
 
@@ -58,7 +59,7 @@ namespace MicroService.Service.Services.Base
             for (int i = 0; i < attributes.Count; i++)
             {
                 var key = attributes[i].Key;
-                var featureName = GetFeatureName(key);
+                var featureName = GetFeatureName(key) ?? key;
                 var propertyInfo = typeof(TShape).GetProperty(key);
 
                 if (propertyInfo != null)
@@ -70,7 +71,7 @@ namespace MicroService.Service.Services.Base
                     {
                         try
                         {
-                            object convertedValue = null;
+                            object? convertedValue = null;
                             if (typeOfMyProperty == typeof(int))
                             {
                                 if (int.TryParse(value.ToString(), out int intValue))
@@ -109,7 +110,7 @@ namespace MicroService.Service.Services.Base
                     }
                     else
                     {
-                        attributes[i] = new KeyValuePair<string, object>(featureName, value);
+                        attributes[i] = new KeyValuePair<string, object>(featureName, value!);
                     }
                 }
             }
@@ -154,7 +155,7 @@ namespace MicroService.Service.Services.Base
             return default;
         }
 
-        public string GetFeatureName(string propertyName)
+        public string? GetFeatureName(string propertyName)
         {
             TShape shapeClass = Activator.CreateInstance<TShape>();
             var featureName = ReflectionExtensions.GetAttributeFromProperty<FeatureNameAttribute>(shapeClass, propertyName);
@@ -196,14 +197,15 @@ namespace MicroService.Service.Services.Base
             return results;
         }
 
-        public virtual TShape GetFeatureLookup(double x, double y, Datum datum)
+        public virtual TShape? GetFeatureLookup(double x, double y, Datum datum)
         {
             ShapePropertiesAttribute shapePropertiesAttribute = typeof(TShape)
                 .GetCustomAttributes(typeof(ShapePropertiesAttribute), false)
                 .OfType<ShapePropertiesAttribute>()
-                .SingleOrDefault();
+                .SingleOrDefault()
+                ?? throw new InvalidOperationException($"{typeof(TShape)} does not declare a {nameof(ShapePropertiesAttribute)}.");
 
-            ShapeProperties shapeProperties = shapePropertiesAttribute!.ShapeProperties;
+            ShapeProperties shapeProperties = shapePropertiesAttribute.ShapeProperties;
             Datum sourceDatum = shapeProperties.GetAttribute<ShapeAttribute>().Datum;
 
             (x, y) = TransformCoordinates(x, y, datum, sourceDatum);
@@ -226,17 +228,20 @@ namespace MicroService.Service.Services.Base
 
         private (double, double) TransformCoordinates(double x, double y, Datum fromDatum, Datum toDatum)
         {
+            // GeoTransformationHelper only returns null components when its own x/y
+            // arguments are null; x and y here are non-nullable doubles, so the
+            // conversion result is always populated.
             if (fromDatum != toDatum)
             {
                 if (fromDatum == Datum.Nad83 && toDatum == Datum.Wgs84)
                 {
                     var (x1, y1) = GeoTransformationHelper.ConvertNad83ToWgs84(x, y);
-                    return (x1.Value, y1.Value);
+                    return (x1!.Value, y1!.Value);
                 }
                 else if (fromDatum == Datum.Wgs84 && toDatum == Datum.Nad83)
                 {
                     var (x1, y1) = GeoTransformationHelper.ConvertWgs84ToNad83(x, y);
-                    return (x1.Value, y1.Value);
+                    return (x1!.Value, y1!.Value);
                 }
             }
 

--- a/src/MicroService.Service/Services/IndividualLandmarkHistoricDistrictsService.cs
+++ b/src/MicroService.Service/Services/IndividualLandmarkHistoricDistrictsService.cs
@@ -68,7 +68,7 @@ namespace MicroService.Service.Services
 
             if (attributes.Any(a => a.Key.Equals("LPNumber", StringComparison.InvariantCultureIgnoreCase)))
             {
-                var lpNumberValue = attributes.First(a => a.Key.Equals("LPNumber", StringComparison.InvariantCultureIgnoreCase)).Value.ToString();
+                var lpNumberValue = attributes.First(a => a.Key.Equals("LPNumber", StringComparison.InvariantCultureIgnoreCase)).Value.ToString() ?? string.Empty;
                 var propertyAttributes = new List<KeyValuePair<string, object>>
                 {
                     new KeyValuePair<string, object>("LPNumber", lpNumberValue)

--- a/src/MicroService.Service/Services/SubwayService.cs
+++ b/src/MicroService.Service/Services/SubwayService.cs
@@ -25,11 +25,13 @@ namespace MicroService.Service.Services
             ShapeFileDataReader = shapefileDataReaderResolver(nameof(ShapeProperties.Subway));
         }
 
-        public override SubwayShape GetFeatureLookup(double x, double y, Datum datum)
+        public override SubwayShape? GetFeatureLookup(double x, double y, Datum datum)
         {
             // Validate Point is in Range
+            // ConvertNad83ToWgs84 only returns null components when its x/y arguments
+            // are null; x and y here are non-nullable doubles, so the result is always populated.
             var result = GeoTransformationHelper.ConvertNad83ToWgs84(x, y);
-            var point = new Point(result.Item1.Value, result.Item2.Value);
+            var point = new Point(result.Item1!.Value, result.Item2!.Value);
 
             var features = GetFeatures();
             var subwayStops = new List<SubwayShape>(features.Count);
@@ -39,9 +41,9 @@ namespace MicroService.Service.Services
                 var distance = f.Geometry.Distance(point);
                 var model = new SubwayShape
                 {
-                    Line = f.Attributes["line"].ToString(),
-                    Name = f.Attributes["name"].ToString(),
-                    ObjectId = int.Parse(f.Attributes["objectid"].ToString()),
+                    Line = f.Attributes["line"].ToString() ?? string.Empty,
+                    Name = f.Attributes["name"].ToString() ?? string.Empty,
+                    ObjectId = int.Parse(f.Attributes["objectid"].ToString() ?? string.Empty),
                     Distance = distance,
                 };
 

--- a/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -30,12 +30,15 @@ namespace MicroService.WebApi.Extensions
         {
             var config = configuration.Get<ApplicationOptions>();
             var shapeRootDirectory = config?.ShapeConfiguration?.ShapeRootDirectory;
-            var shapeCronExpressionDescription = CronExpressionDescriptor.ExpressionDescriptor.GetDescription(config?.ShapeConfiguration?.CronExpression ?? string.Empty);
+            var shapeCronExpression = config?.ShapeConfiguration?.CronExpression;
+            var shapeCronExpressionDescription = string.IsNullOrWhiteSpace(shapeCronExpression)
+                ? "(not configured)"
+                : CronExpressionDescriptor.ExpressionDescriptor.GetDescription(shapeCronExpression);
 
             Console.WriteLine($"PostgreSql: {config?.ConnectionStrings?.PostgreSql}");
             Console.WriteLine($"ShapeRootDirectory Config: {shapeRootDirectory}");
             Console.WriteLine($"ShapeRootDirectory: {(shapeRootDirectory == null ? "(not configured)" : Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), shapeRootDirectory)))}");
-            Console.WriteLine($"Shape CronExpression: {config?.ShapeConfiguration?.CronExpression}");
+            Console.WriteLine($"Shape CronExpression: {shapeCronExpression}");
             Console.WriteLine($"Shape Cron Description: {shapeCronExpressionDescription}");
         }
 

--- a/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MicroService.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -29,12 +29,13 @@ namespace MicroService.WebApi.Extensions
         public static void DisplayConfiguration(this IServiceCollection services, IConfiguration configuration)
         {
             var config = configuration.Get<ApplicationOptions>();
-            var shapeCronExpressionDescription = CronExpressionDescriptor.ExpressionDescriptor.GetDescription(config!.ShapeConfiguration?.CronExpression);
+            var shapeRootDirectory = config?.ShapeConfiguration?.ShapeRootDirectory;
+            var shapeCronExpressionDescription = CronExpressionDescriptor.ExpressionDescriptor.GetDescription(config?.ShapeConfiguration?.CronExpression ?? string.Empty);
 
             Console.WriteLine($"PostgreSql: {config?.ConnectionStrings?.PostgreSql}");
-            Console.WriteLine($"ShapeRootDirectory Config: {config?.ShapeConfiguration?.ShapeRootDirectory}");
-            Console.WriteLine($"ShapeRootDirectory: {Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), config?.ShapeConfiguration?.ShapeRootDirectory))}");
-            Console.WriteLine($"Shape CronExpression: {config.ShapeConfiguration.CronExpression}");
+            Console.WriteLine($"ShapeRootDirectory Config: {shapeRootDirectory}");
+            Console.WriteLine($"ShapeRootDirectory: {(shapeRootDirectory == null ? "(not configured)" : Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), shapeRootDirectory)))}");
+            Console.WriteLine($"Shape CronExpression: {config?.ShapeConfiguration?.CronExpression}");
             Console.WriteLine($"Shape Cron Description: {shapeCronExpressionDescription}");
         }
 
@@ -132,8 +133,9 @@ namespace MicroService.WebApi.Extensions
         {
             var serviceVersion = Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
 
-            var commonConfig = configuration.Get<MicroService.Common.Configuration.ApplicationOptions>();
-            if (commonConfig!.JaegerConfiguration.Enabled)
+            var commonConfig = configuration.Get<MicroService.Common.Configuration.ApplicationOptions>()
+                ?? throw new InvalidOperationException("Application configuration could not be loaded.");
+            if (commonConfig.JaegerConfiguration?.Enabled == true)
             {
                 services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
                 {

--- a/src/MicroService.WebApi/Program.cs
+++ b/src/MicroService.WebApi/Program.cs
@@ -106,10 +106,15 @@ void SetupServices()
 
 void AddServices()
 {
-    var config = configuration.Get<ApplicationOptions>();
+    var config = configuration.Get<ApplicationOptions>()
+        ?? throw new InvalidOperationException("Application configuration could not be loaded.");
+    var connectionString = config.ConnectionStrings?.PostgreSql
+        ?? throw new InvalidOperationException("ConnectionStrings:PostgreSql configuration is required.");
+    var shapeConfiguration = config.ShapeConfiguration
+        ?? throw new InvalidOperationException("ShapeConfiguration is required.");
 
     // Repositories
-    services.AddScoped<ITestDataRepository>(x => new TestDataRepository(config!.ConnectionStrings.PostgreSql));
+    services.AddScoped<ITestDataRepository>(x => new TestDataRepository(connectionString));
 
     // Services
     services.AddScoped<ICalculationService, CalculationService>();
@@ -152,11 +157,12 @@ void AddServices()
         else
             throw new KeyNotFoundException(key);
 
-        var options = serviceProvider.GetService<IOptions<ApplicationOptions>>();
-        var cache = serviceProvider.GetService<IMemoryCache>();
+        var options = serviceProvider.GetRequiredService<IOptions<ApplicationOptions>>();
+        var cache = serviceProvider.GetRequiredService<IMemoryCache>();
 
-        var rootDirectory = options?.Value?.ShapeConfiguration.ShapeSystemRootDirectory;
-        string shapeFileNamePath = Path.Combine(rootDirectory!, shapeProperties.Directory, shapeProperties.FileName);
+        var rootDirectory = options.Value.ShapeConfiguration?.ShapeSystemRootDirectory
+            ?? throw new InvalidOperationException("ShapeConfiguration:ShapeRootDirectory configuration is required.");
+        string shapeFileNamePath = Path.Combine(rootDirectory, shapeProperties.Directory, shapeProperties.FileName);
 
         return new CachedShapefileDataReader(cache, key, shapeFileNamePath);
     });
@@ -217,14 +223,16 @@ void AddServices()
     services.AddCronJob<InMemoryCacheShapefileCronJobService>(x =>
     {
         x.TimeZoneInfo = TimeZoneInfo.Local;
-        x.CronExpression = config!.ShapeConfiguration.CronExpression;
+        x.CronExpression = shapeConfiguration.CronExpression;
     });
 }
 
 void AddHealthCheckServices()
 {
-    var config = configuration.Get<ApplicationOptions>();
-    var shapeDirectory = config!.ShapeConfiguration.ShapeRootDirectory;
+    var config = configuration.Get<ApplicationOptions>()
+        ?? throw new InvalidOperationException("Application configuration could not be loaded.");
+    var shapeDirectory = config.ShapeConfiguration?.ShapeRootDirectory
+        ?? throw new InvalidOperationException("ShapeConfiguration:ShapeRootDirectory configuration is required.");
     string shapePath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), shapeDirectory));
 
     services

--- a/src/MicroService.WebApi/Services/InMemoryCacheShapefileCronJobService.cs
+++ b/src/MicroService.WebApi/Services/InMemoryCacheShapefileCronJobService.cs
@@ -52,7 +52,8 @@ namespace MicroService.WebApi.Services
 
             foreach (var (name, _) in _entries)
             {
-                var rootDirectory = _applicationOptions.Value.ShapeConfiguration.ShapeSystemRootDirectory;
+                var rootDirectory = _applicationOptions.Value.ShapeConfiguration?.ShapeSystemRootDirectory
+                    ?? throw new InvalidOperationException("ShapeConfiguration:ShapeRootDirectory configuration is required.");
                 var directory = Enum.Parse<ShapeProperties>(name).GetAttribute<ShapeAttribute>().Directory;
                 var file = Enum.Parse<ShapeProperties>(name).GetAttribute<ShapeAttribute>().FileName;
 
@@ -93,7 +94,8 @@ namespace MicroService.WebApi.Services
 
             foreach (var (name, shapeAttribute) in nameWithShapeAttributes)
             {
-                var rootDirectory = _applicationOptions.Value.ShapeConfiguration.ShapeSystemRootDirectory;
+                var rootDirectory = _applicationOptions.Value.ShapeConfiguration?.ShapeSystemRootDirectory
+                    ?? throw new InvalidOperationException("ShapeConfiguration:ShapeRootDirectory configuration is required.");
                 var directory = shapeAttribute.Directory;
                 var file = $"{shapeAttribute.FileName}.dbf";
 

--- a/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
@@ -199,8 +199,11 @@ namespace MicroService.WebApi.V1.Controllers
             if (string.IsNullOrEmpty(request?.Key) || !Enum.IsDefined(typeof(ShapeProperties), request.Key))
                 return BadRequest();
 
-            var keys = request.Attributes!.Select(kv => kv.Key).ToList();
-            var service = _shapeServiceResolver!(request?.Key!);
+            if (request.Attributes is null || request.Attributes.Count == 0)
+                return BadRequest("Attributes are required.");
+
+            var keys = request.Attributes.Select(kv => kv.Key).ToList();
+            var service = _shapeServiceResolver!(request.Key);
 
             var shapeType = service.GetType().GetInterface("IShapeService`1")!.GetGenericArguments()[0];
 
@@ -216,7 +219,7 @@ namespace MicroService.WebApi.V1.Controllers
                 return BadRequest($"The following attributes are not valid for the selected shape type: {invalidFields}");
             }
 
-            var featureCollection = _shapeServiceResolver(request!.Key).GetFeatureCollection(request.Attributes!);
+            var featureCollection = service.GetFeatureCollection(request.Attributes);
             if (featureCollection == null)
                 return NotFound();
 
@@ -247,8 +250,13 @@ namespace MicroService.WebApi.V1.Controllers
                 return BadRequest();
             }
 
-            var keys = request.Attributes!.Select(kv => kv.Key).ToList();
-            var service = _shapeServiceResolver!(request?.Key!);
+            if (request.Attributes is null || request.Attributes.Count == 0)
+            {
+                return BadRequest("Attributes are required.");
+            }
+
+            var keys = request.Attributes.Select(kv => kv.Key).ToList();
+            var service = _shapeServiceResolver!(request.Key);
 
             var shapeType = service.GetType().GetInterface("IShapeService`1")!.GetGenericArguments()[0];
 
@@ -268,7 +276,7 @@ namespace MicroService.WebApi.V1.Controllers
                 return BadRequest($"The following attributes are not valid for the selected shape type: {invalidFields}");
             }
 
-            var results = lookupFunction(service, request!.Attributes!).ToList();
+            var results = lookupFunction(service, request.Attributes).ToList();
             if (!results.Any())
             {
                 return NotFound();

--- a/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
@@ -216,7 +216,7 @@ namespace MicroService.WebApi.V1.Controllers
                 return BadRequest($"The following attributes are not valid for the selected shape type: {invalidFields}");
             }
 
-            var featureCollection = _shapeServiceResolver(request!.Key).GetFeatureCollection(request.Attributes);
+            var featureCollection = _shapeServiceResolver(request!.Key).GetFeatureCollection(request.Attributes!);
             if (featureCollection == null)
                 return NotFound();
 

--- a/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
+++ b/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
@@ -174,6 +174,51 @@ namespace MicroService.Test.Controllers
             Assert.IsType<BadRequestResult>(sut.Result);
         }
 
+        [Fact]
+        public async Task GetAttributeLookup_WithMissingAttributes_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel { Key = "BoroughBoundaries", Attributes = null };
+
+            var controller = GetFeatureServiceController();
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithEmptyAttributes_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel { Key = "BoroughBoundaries", Attributes = new List<KeyValuePair<string, object>>() };
+
+            var controller = GetFeatureServiceController();
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetLookupFeatureGeoJson_WithMissingAttributes_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel { Key = "BoroughBoundaries", Attributes = null };
+
+            var controller = GetFeatureServiceController();
+
+            // Act
+            var result = await controller.GetLookupFeatureGeoJson(request);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+        }
+
         private static FeatureServiceController GetFeatureServiceController(ShapeServiceResolver? resolver = null)
         {
 


### PR DESCRIPTION
## Summary

Third and final PR in the `Analyze`-warning cleanup stack (stacked on #483). Resolves every remaining `src/` nullable-reference warning outside `Models/` and `Mappings/` — the `Helpers/`, `Services/`, `Configuration/`, `Data/Repository/`, and `WebApi` startup/DI code.

- `EnumHelper.GetAttribute<T>` / `GetEnumDescription`: guard `Enum.GetName`/`Type.GetField` null results; throw with a clear message where every real call site already assumes the attribute/field exists and dereferences immediately with no null-check.
- `FileHelpers`: replace obsolete `Assembly.CodeBase` (SYSLIB0012, also nullable) with `Assembly.Location` — removes both warnings with one fix.
- `ReflectionExtensions.GetAttributeFromProperty`: **kept** its nullable-return contract (an existing test, `GetAttributeFromProperty_PropertyDoesNotHaveAttribute_ReturnsNull`, asserts this), only hardened the genuinely-invalid "property doesn't exist" case.
- `AbstractShapeService`: `ShapeFileDataReader` is always assigned by every derived service's constructor (confirmed across all 16), so `= null!` documents that instead of leaving it uninitialized. `GetFeatureLookup(x, y, datum)` and `IShapeService<T>`'s matching interface member now return `T?` — every real caller (the controller, `SubwayService`'s override) already null-checks the result, so the non-nullable declared return type was the actual bug.
- `SubwayService`, `TestDataRepository`, `ShapeConfiguration`, `IndividualLandmarkHistoricDistrictsService`: same guard-or-throw treatment — safe default for genuinely optional values, throw with a clear message where the operation cannot proceed without it.
- `Program.cs` / `ServiceCollectionExtensions` / `InMemoryCacheShapefileCronJobService`: fail fast with `InvalidOperationException` when required configuration (connection string, shape root directory) is missing at startup; use `GetRequiredService` instead of `GetService` for DI registrations that are always present.

## A course-correction worth flagging

My first pass at `ReflectionExtensions.GetAttributeFromProperty` and `AbstractShapeService.GetFeatureName` changed the "attribute not found" case to throw. Rebuilding and tracing callers, I found several shape models (`IndividualLandmarkSiteShape`, `HistoricDistrictShape`, etc.) have `BoroCode` properties with **no** `[FeatureName]` attribute — and an existing test explicitly asserts the null-return contract. Reverted to the original nullable-return behavior and instead fixed `ValidateFeatureKey`'s single call site to fall back to the raw key (`GetFeatureName(key) ?? key`) when the attribute is absent, which is what the code needed all along.

## Validation

- `make analyze` — 0 warnings remain in any `src/` project (verified via `dotnet build --no-incremental` across the whole solution); all remaining warnings (25 unique) are pre-existing and confined to `test/`, out of scope for this stack
- `make test` — 228 passed, 12 skipped (unchanged from baseline), despite the `IShapeService<T>.GetFeatureLookup` signature change (`T` → `T?`)
- `make check` — passed

## Risk

Low-to-moderate. Most changes are mechanical null-guards, but this PR does change two public contracts:
- `IShapeService<T>.GetFeatureLookup(double, double, Datum)` return type: `T` → `T?`. Every current caller already null-checks the result (confirmed via `FeatureServiceController`, `SubwayService`), so this makes an existing implicit contract explicit rather than changing behavior.
- Several startup paths (`Program.cs`, cron job service) now throw `InvalidOperationException` immediately if required configuration is missing, instead of a later, less clear `NullReferenceException`/`ArgumentNullException` deep in a request or background job. This is a deliberate fail-fast improvement, not a behavior regression, for configuration that was already effectively required.