### PR TITLE
build: remove test warning overrides

### DIFF
--- a/test/MicroService.Test/MicroService.Test.csproj
+++ b/test/MicroService.Test/MicroService.Test.csproj
@@ -5,8 +5,6 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-		<NoWarn>$(NoWarn),1701;1702;1705,NU1803</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- remove the test project's local `TreatWarningsAsErrors=False` override
- remove the test project's local `NoWarn` override because the project builds cleanly without it
- keep the change focused to the test project so the auto-approve workflow can be exercised on a minimal PR

## Validation
- `make check`: pass
- `make build`: pass
- `make test`: pass (243 total, 231 passed, 0 failed, 12 skipped)
- `make analyze`: pass
- `dotnet build test/MicroService.Test/MicroService.Test.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true`: pass

## Dependency / Stack Info
- .NET SDK: 10.0.302
- Branch: `chore/remove-test-warning-overrides`
- Base: `master`

## Known Risks
- No runtime behavior changes expected; this only removes now-unneeded warning overrides from the test project.
- Remaining warning-debt cleanup still exists in other project-level `NoWarn` entries and should be handled in follow-up PRs.