### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Summary
-- 
+- Describe the change.
 
 ## Validation
 - [ ] `make check`
@@ -8,15 +8,15 @@
 - [ ] `make analyze`
 
 Validation results:
-- 
+- Summarize command outcomes and notable details.
 
 ## Dependency / Stack Info
-- Base branch: `master`
+- Base branch:
 - Stack dependencies:
 - Related PRs:
 
 ## Known Risks
-- 
+- Describe any known risks or write `None`.
 
 ## Review Follow-Up
 - [ ] GitHub Copilot review completed on the current head SHA

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+- 
+
+## Validation
+- [ ] `make check`
+- [ ] `make build`
+- [ ] `make test`
+- [ ] `make analyze`
+
+Validation results:
+- 
+
+## Dependency / Stack Info
+- Base branch: `master`
+- Stack dependencies:
+- Related PRs:
+
+## Known Risks
+- 
+
+## Review Follow-Up
+- [ ] GitHub Copilot review completed on the current head SHA
+- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
+- [ ] Required review threads resolved
+- [ ] No newer commit or rebase invalidated completed review or CI results
+
+## Merge Readiness
+- [ ] PR is ready for review and conflict-free
+- [ ] Required lint, build, and test checks pass on the current head SHA
+- [ ] Required code scanning checks pass on the current head SHA
+- [ ] For a stack, every layer satisfies the same checklist


### PR DESCRIPTION
## Summary
- add a repository pull request template under `.github/`
- align the template sections with the repo's existing PR instructions: summary, validation, stack info, risks, Copilot follow-up, and merge-readiness
- make the expected review and validation evidence explicit so routine PR hygiene is easier to follow

## Validation
- `make check`: pass

Validation results:
- Added `.github/pull_request_template.md`
- `make check` passed after the template was added

## Dependency / Stack Info
- Base branch: `master`
- Stack dependencies: none
- Related PRs: none

## Known Risks
- No runtime or build behavior changes; this only adds PR authoring guidance.
- Workflow linting and other guardrails are intentionally left for follow-up PRs to keep this change focused.

## Review Follow-Up
- [x] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness
- [x] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist