### PR TITLE
fix: close the analyze/sonar analyzer gap for real Roslyn diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.cs]
+# Elevate analyzer diagnostics that SonarQube's external_roslyn category already
+# reports at Info/Suggestion severity, so `make analyze` catches them locally too.
+dotnet_diagnostic.CA1816.severity = warning
+dotnet_diagnostic.CA1822.severity = warning
+dotnet_diagnostic.CA1860.severity = warning
+dotnet_diagnostic.CA1861.severity = warning
+dotnet_diagnostic.SYSLIB1045.severity = warning
+dotnet_diagnostic.xUnit1042.severity = warning
+dotnet_diagnostic.xUnit2032.severity = warning

--- a/src/MicroService.Common/Health/HealthCheckServerExtensions.cs
+++ b/src/MicroService.Common/Health/HealthCheckServerExtensions.cs
@@ -4,9 +4,11 @@ namespace MicroService.Common.Health
 {
     public static class HealthCheckServerExtensions
     {
+        private static readonly string[] SystemTag = { "System" };
+
         public static IHealthChecksBuilder AddVersionHealthCheck(this IHealthChecksBuilder builder)
         {
-            builder.AddCheck<VersionHealthCheck>("Version Health Check", tags: new[] { "System" });
+            builder.AddCheck<VersionHealthCheck>("Version Health Check", tags: SystemTag);
 
             return builder;
         }

--- a/src/MicroService.Service/Helpers/StringHelper.cs
+++ b/src/MicroService.Service/Helpers/StringHelper.cs
@@ -2,11 +2,14 @@
 
 namespace MicroService.Service.Helpers
 {
-    public static class StringHelper
+    public static partial class StringHelper
     {
         public static string RemoveIntegers(this string input)
         {
-            return Regex.Replace(input, @"[\d-]", string.Empty);
+            return DigitsAndHyphensRegex().Replace(input, string.Empty);
         }
+
+        [GeneratedRegex(@"[\d-]")]
+        private static partial Regex DigitsAndHyphensRegex();
     }
 }

--- a/src/MicroService.Service/Mappings/Base/ShapeProfile.cs
+++ b/src/MicroService.Service/Mappings/Base/ShapeProfile.cs
@@ -7,13 +7,13 @@ using System.Text.RegularExpressions;
 
 namespace MicroService.Service.Mappings.Base
 {
-    public abstract class ShapeProfile<TShape> : Profile where TShape : class
+    public abstract partial class ShapeProfile<TShape> : Profile where TShape : class
     {
         protected ShapeProfile()
         {
             CreateMap<TShape, IDictionary<string, object>>()
                 .ConvertUsing(shape => shape.GetType().GetProperties()
-                    .Where(prop => !prop.GetCustomAttributes(typeof(FeatureCollectionExcludeAttribute), false).Any())
+                    .Where(prop => prop.GetCustomAttributes(typeof(FeatureCollectionExcludeAttribute), false).Length == 0)
                     // No shape model exposes a nullable-valued property, so GetValue(shape) is
                     // never actually null here; PropertyInfo.GetValue's object? return is a
                     // general reflection contract, not a real possibility for this closed set of types.
@@ -46,7 +46,10 @@ namespace MicroService.Service.Mappings.Base
         protected static string? GetSanitizedString(Feature src, string key)
         {
             var value = GetString(src, key);
-            return string.IsNullOrEmpty(value) ? null : Regex.Replace(value, @"\u0000", string.Empty);
+            return string.IsNullOrEmpty(value) ? null : NullCharacterRegex().Replace(value, string.Empty);
         }
+
+        [GeneratedRegex(@"\u0000")]
+        private static partial Regex NullCharacterRegex();
     }
 }

--- a/src/MicroService.Service/Mappings/IndividualLandmarkSiteShapeProfile.cs
+++ b/src/MicroService.Service/Mappings/IndividualLandmarkSiteShapeProfile.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 
 namespace MicroService.Service.Mappings
 {
-    public class IndividualLandmarkSiteShapeProfile : ShapeProfile<IndividualLandmarkSiteShape>
+    public partial class IndividualLandmarkSiteShapeProfile : ShapeProfile<IndividualLandmarkSiteShape>
     {
         public IndividualLandmarkSiteShapeProfile()
         {
@@ -55,8 +55,11 @@ namespace MicroService.Service.Mappings
             var alternativeName = GetString(src, "lpc_altern");
             return string.IsNullOrEmpty(alternativeName)
                 ? null
-                : Regex.Replace(alternativeName, @"\u0000", string.Empty);
+                : NullCharacterRegex().Replace(alternativeName, string.Empty);
         }
+
+        [GeneratedRegex(@"\u0000")]
+        private static partial Regex NullCharacterRegex();
     }
 
 }

--- a/src/MicroService.Service/Services/Base/AbstractShapeService.cs
+++ b/src/MicroService.Service/Services/Base/AbstractShapeService.cs
@@ -226,7 +226,7 @@ namespace MicroService.Service.Services.Base
         public IReadOnlyCollection<Feature> GetFeatures() =>
                 ShapeFileDataReader.GetFeatures();
 
-        private (double, double) TransformCoordinates(double x, double y, Datum fromDatum, Datum toDatum)
+        private static (double, double) TransformCoordinates(double x, double y, Datum fromDatum, Datum toDatum)
         {
             // GeoTransformationHelper only returns null components when its own x/y
             // arguments are null; x and y here are non-nullable doubles, so the

--- a/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
+++ b/src/MicroService.WebApi/V1/Controllers/FeatureServiceController.cs
@@ -213,7 +213,7 @@ namespace MicroService.WebApi.V1.Controllers
             var allFields = fields.Union(mappingFields).ToList();
 
             var invalidItems = keys.Where(x => !allFields.Contains(x)).ToList();
-            if (invalidItems.Any())
+            if (invalidItems.Count > 0)
             {
                 var invalidFields = string.Join(", ", invalidItems);
                 return BadRequest($"The following attributes are not valid for the selected shape type: {invalidFields}");
@@ -270,14 +270,14 @@ namespace MicroService.WebApi.V1.Controllers
             var allFields = fields.Union(mappingFields).ToList();
 
             var invalidItems = keys.Where(x => !allFields.Contains(x)).ToList();
-            if (invalidItems.Any())
+            if (invalidItems.Count > 0)
             {
                 var invalidFields = string.Join(", ", invalidItems);
                 return BadRequest($"The following attributes are not valid for the selected shape type: {invalidFields}");
             }
 
             var results = lookupFunction(service, request.Attributes).ToList();
-            if (!results.Any())
+            if (results.Count == 0)
             {
                 return NotFound();
             }

--- a/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
+++ b/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
@@ -18,11 +18,11 @@ namespace MicroService.Test.Controllers
 {
     public class FeatureServiceControllerTests
     {
-        public static IEnumerable<object[]> ValidRequests =>
-            new List<object[]>
+        public static TheoryData<string, List<ShapeBase>> ValidRequests =>
+            new()
             {
-            new object[] { "BoroughBoundaries", new List<ShapeBase> { new BoroughBoundaryShape(), new CommunityDistrictShape() } },
-            new object[] { "CommunityDistricts", new List<ShapeBase> { new CommunityDistrictShape(), new CommunityDistrictShape() } }
+                { "BoroughBoundaries", new List<ShapeBase> { new BoroughBoundaryShape(), new CommunityDistrictShape() } },
+                { "CommunityDistricts", new List<ShapeBase> { new CommunityDistrictShape(), new CommunityDistrictShape() } }
             };
 
         [Theory]
@@ -75,7 +75,7 @@ namespace MicroService.Test.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(sut.Result);
-            var shapesResult = Assert.IsAssignableFrom<IEnumerable<object>>(okResult.Value);
+            var shapesResult = Assert.IsType<IEnumerable<object>>(okResult.Value, exactMatch: false);
 
             Assert.All(shapesResult, Assert.NotNull);
         }

--- a/test/MicroService.Test/Fixture/TestDataFixture.cs
+++ b/test/MicroService.Test/Fixture/TestDataFixture.cs
@@ -1,5 +1,6 @@
 ﻿using MicroService.Data.Repository;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace MicroService.Test.Fixture
 {
@@ -18,6 +19,7 @@ namespace MicroService.Test.Fixture
 
         public override void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/MicroService.Test/Functions/EnumHelperTest.cs
+++ b/test/MicroService.Test/Functions/EnumHelperTest.cs
@@ -60,7 +60,7 @@ namespace MicroService.Test.Functions
             // Arrange
             var expectedProperties = typeof(HistoricDistrictShape)
                 .GetProperties()
-                .Where(p => !p.GetCustomAttributes(typeof(FeatureCollectionExcludeAttribute), true).Any())
+                .Where(p => p.GetCustomAttributes(typeof(FeatureCollectionExcludeAttribute), true).Length == 0)
                 .ToList();
 
             // Act

--- a/test/MicroService.Test/Mock/CalculationServiceMock.cs
+++ b/test/MicroService.Test/Mock/CalculationServiceMock.cs
@@ -37,7 +37,7 @@ namespace MicroService.Test.Mock
             Assert.Equal(result, sut);
         }
 
-        private CalculationService GetCalculationService(ITestDataRepository? testDataRepository = null)
+        private static CalculationService GetCalculationService(ITestDataRepository? testDataRepository = null)
         {
             testDataRepository ??= new Mock<ITestDataRepository>().Object;
 

--- a/test/MicroService.Test/Unit/WktReaderFunctions.cs
+++ b/test/MicroService.Test/Unit/WktReaderFunctions.cs
@@ -6,6 +6,8 @@ namespace MicroService.Test.Unit
 {
     public static class WktReaderFunctions
     {
+        private static readonly bool[] Inside = { false, true, true, true };
+
         public static void GeometryContainsPoint()
         {
             var services = NtsGeometryServices.Instance;
@@ -25,12 +27,10 @@ namespace MicroService.Test.Unit
                 factory.CreatePoint(new Coordinate(429016.9, 360413.04))
             });
 
-            var inside = new List<bool>(new[] { false, true, true, true });
-
             for (var i = 0; i < points.Count; i++)
             {
                 var contains = poly.Contains(points[i]);
-                var expected = inside[i];
+                var expected = Inside[i];
 
                 Assert.Equal(expected, contains);
 

--- a/test/MicroService.Test/Unit/WktReaderFunctions.cs
+++ b/test/MicroService.Test/Unit/WktReaderFunctions.cs
@@ -34,7 +34,7 @@ namespace MicroService.Test.Unit
 
                 Assert.Equal(expected, contains);
 
-                System.Console.Write(poly.Contains(points[i]));
+                System.Console.Write(contains);
             }
         }
 


### PR DESCRIPTION
## Summary
- `make analyze` built clean (0 warnings) while `make sonar` reported 63 issues on the same codebase. Root cause: 7 real Roslyn/xUnit analyzer rules (`CA1816`, `CA1822`, `CA1860`, `CA1861`, `SYSLIB1045`, `xUnit1042`, `xUnit2032`) default to `Suggestion`/`Info` severity in a plain `dotnet build`, so `TreatWarningsAsErrors` never sees them — Sonar only surfaces them because `dotnet-sonarscanner` re-runs Roslyn analyzers with a lower severity threshold. The repo had no `.editorconfig` to align local severity with what Sonar reports.
- Added `.editorconfig` elevating those 7 rule IDs to `warning`, then fixed every finding they surface (16 total):
  - `CA1861` — extracted constant array arguments to `static readonly` fields (2 sites).
  - `SYSLIB1045` — converted 3 `Regex.Replace` call sites to source-generated `[GeneratedRegex]` partial methods.
  - `CA1860` — compare `Count`/`Length` instead of calling `.Any()` (5 sites).
  - `CA1822` — marked instance methods that don't touch instance state `static` (2 sites).
  - `CA1816` — `TestDataFixture.Dispose()` now calls `GC.SuppressFinalize(this)`.
  - `xUnit1042` — converted `FeatureServiceControllerTests.ValidRequests` from `IEnumerable<object[]>` to `TheoryData<string, List<ShapeBase>>`.
  - `xUnit2032` — replaced `Assert.IsAssignableFrom` with `Assert.IsType(..., exactMatch: false)`.

## What's intentionally still out of `make analyze`'s reach
- **`xUnit1004`** (11 Sonar findings, "re-enable this skipped test"): all point at tests explicitly marked `Skip = "TODO: FIX"` / `"TO DO REMOVE"` — deliberately disabled, not analyzer oversights. Re-enabling 11 tests as a side effect of an analyzer-alignment change risked turning CI red for unrelated reasons, so this rule was left at its default severity. Worth a separate, deliberate pass.
- **`csharpsquid:*`** (~30 findings) — SonarQube's own proprietary C# analyzer engine (cognitive complexity, "define a constant instead of a literal", etc.). This runs entirely inside `dotnet-sonarscanner`/the SonarQube server, not as a Roslyn analyzer package, so it structurally cannot appear in a plain `dotnet build` regardless of `.editorconfig`.
- **`docker:*` / `css:*`** (~10 findings) — Sonar's Docker and CSS analyzers, outside .NET/Roslyn's domain entirely.

## Validation
- [x] `make check`
- [x] `make build`
- [x] `make test`
- [x] `make analyze`

Validation results:
- `make analyze`: 0 warnings, 0 errors (previously undetectable findings now caught and fixed).
- `make build` (Debug): 0 warnings, 0 errors.
- `make test`: 231 passed, 0 failed, 12 skipped (pre-existing `xUnit1004` skips, untouched).
- `make check` (pre-commit: shellcheck, codespell, yaml/json checks): all passed.

## Dependency / Stack Info
- Base branch: master
- Stack dependencies: None
- Related PRs: Follows #490 (Cloud Run secret fix, merged)

## Known Risks
- `.editorconfig` is new to this repo; the 7 elevated rules are scoped narrowly (not a broad style policy change) to avoid unrelated churn, per this repo's analyzer-remediation skill guidance.
- `xUnit1004` findings remain unresolved by design — flagging here so they aren't mistaken for an oversight.

## Review Follow-Up
- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness
- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist