### PR TITLE
fix: reduce cognitive complexity in AbstractShapeService

### DIFF
--- a/src/MicroService.Service/Services/Base/AbstractShapeService.cs
+++ b/src/MicroService.Service/Services/Base/AbstractShapeService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
+using System.Reflection;
 
 namespace MicroService.Service.Services.Base
 {
@@ -49,110 +50,100 @@ namespace MicroService.Service.Services.Base
         /// <returns></returns>
         public List<KeyValuePair<string, object>>? ValidateFeatureKey(List<KeyValuePair<string, object>>? attributes)
         {
-            var shapeClass = Activator.CreateInstance<TShape>(); // create an instance of the class
-
             if (attributes == null)
             {
                 return null;
             }
 
+            var shapeClass = Activator.CreateInstance<TShape>(); // create an instance of the class
+
             for (int i = 0; i < attributes.Count; i++)
             {
                 var key = attributes[i].Key;
-                var featureName = GetFeatureName(key) ?? key;
                 var propertyInfo = typeof(TShape).GetProperty(key);
 
-                if (propertyInfo != null)
+                if (propertyInfo == null)
                 {
-                    var typeOfMyProperty = propertyInfo.PropertyType;
-                    var value = attributes[i].Value;
-
-                    if (value != null && value.GetType() != typeOfMyProperty)
-                    {
-                        try
-                        {
-                            object? convertedValue = null;
-                            if (typeOfMyProperty == typeof(int))
-                            {
-                                if (int.TryParse(value.ToString(), out int intValue))
-                                {
-                                    convertedValue = intValue;
-                                }
-                            }
-                            else if (typeOfMyProperty == typeof(double))
-                            {
-                                if (double.TryParse(value.ToString(), out double doubleValue))
-                                {
-                                    convertedValue = doubleValue;
-                                }
-                            }
-                            else if (typeOfMyProperty == typeof(string))
-                            {
-                                convertedValue = Convert.ToString(value);
-                            }
-                            else
-                            {
-                                throw new NotSupportedException($"Converting type {value.GetType()} to {typeOfMyProperty} is not supported.");
-                            }
-
-                            if (convertedValue == null)
-                            {
-                                throw new FormatException($"Failed to convert value of type {value.GetType()} to {typeOfMyProperty}.");
-                            }
-
-                            propertyInfo.SetValue(shapeClass, convertedValue);
-                            attributes[i] = new KeyValuePair<string, object>(featureName, convertedValue);
-                        }
-                        catch (FormatException ex)
-                        {
-                            throw new FormatException($"Failed to convert value of type {value.GetType()} to {typeOfMyProperty}.", ex);
-                        }
-                    }
-                    else
-                    {
-                        attributes[i] = new KeyValuePair<string, object>(featureName, value!);
-                    }
+                    continue;
                 }
+
+                var featureName = GetFeatureName(key) ?? key;
+                var value = attributes[i].Value;
+
+                attributes[i] = value != null && value.GetType() != propertyInfo.PropertyType
+                    ? new KeyValuePair<string, object>(featureName, ConvertAttributeValue(shapeClass!, propertyInfo, value))
+                    : new KeyValuePair<string, object>(featureName, value!);
             }
 
             return attributes;
         }
 
-        protected object? MatchAttributeValue(object value, object expectedValue)
+        private static object ConvertAttributeValue(TShape shapeClass, PropertyInfo propertyInfo, object value)
         {
-            if (value is string s)
-            {
-                if (expectedValue is string es)
-                {
-                    return s == es ? s : null;
-                }
-            }
-            else if (value is int i)
-            {
-                if (expectedValue is int ei)
-                {
-                    return i == ei ? i : null;
-                }
-                else if (expectedValue is double ed)
-                {
-                    return i == (int)ed ? i : null;
-                }
-            }
-            else if (value is double d)
-            {
-                if (expectedValue is int ei)
-                {
-                    return (int)d == ei ? d : null;
-                }
+            var typeOfMyProperty = propertyInfo.PropertyType;
 
-                if (expectedValue is double ed)
-                {
-                    const double tolerance = 1e-9;
-                    return Math.Abs(d - ed) <= tolerance ? d : null;
-                }
+            try
+            {
+                var convertedValue = ConvertToPropertyType(value, typeOfMyProperty)
+                    ?? throw new FormatException($"Failed to convert value of type {value.GetType()} to {typeOfMyProperty}.");
+
+                propertyInfo.SetValue(shapeClass, convertedValue);
+                return convertedValue;
+            }
+            catch (FormatException ex)
+            {
+                throw new FormatException($"Failed to convert value of type {value.GetType()} to {typeOfMyProperty}.", ex);
+            }
+        }
+
+        private static object? ConvertToPropertyType(object value, Type typeOfMyProperty)
+        {
+            if (typeOfMyProperty == typeof(int))
+            {
+                return int.TryParse(value.ToString(), out int intValue) ? intValue : null;
             }
 
-            return default;
+            if (typeOfMyProperty == typeof(double))
+            {
+                return double.TryParse(value.ToString(), out double doubleValue) ? doubleValue : null;
+            }
+
+            if (typeOfMyProperty == typeof(string))
+            {
+                return Convert.ToString(value);
+            }
+
+            throw new NotSupportedException($"Converting type {value.GetType()} to {typeOfMyProperty} is not supported.");
+        }
+
+        protected static object? MatchAttributeValue(object value, object expectedValue) => value switch
+        {
+            string s => MatchString(s, expectedValue),
+            int i => MatchInt(i, expectedValue),
+            double d => MatchDouble(d, expectedValue),
+            _ => null
+        };
+
+        private static object? MatchString(string value, object expectedValue) =>
+            expectedValue is string expected && value == expected ? value : null;
+
+        private static object? MatchInt(int value, object expectedValue) => expectedValue switch
+        {
+            int expected => value == expected ? value : null,
+            double expected => value == (int)expected ? value : null,
+            _ => null
+        };
+
+        private static object? MatchDouble(double value, object expectedValue)
+        {
+            const double tolerance = 1e-9;
+
+            return expectedValue switch
+            {
+                int expected => (int)value == expected ? value : null,
+                double expected => Math.Abs(value - expected) <= tolerance ? value : null,
+                _ => null
+            };
         }
 
         public string? GetFeatureName(string propertyName)

--- a/src/MicroService.Service/Services/Base/AbstractShapeService.cs
+++ b/src/MicroService.Service/Services/Base/AbstractShapeService.cs
@@ -55,7 +55,7 @@ namespace MicroService.Service.Services.Base
                 return null;
             }
 
-            var shapeClass = Activator.CreateInstance<TShape>(); // create an instance of the class
+            var shapeClass = new TShape();
 
             for (int i = 0; i < attributes.Count; i++)
             {
@@ -71,7 +71,7 @@ namespace MicroService.Service.Services.Base
                 var value = attributes[i].Value;
 
                 attributes[i] = value != null && value.GetType() != propertyInfo.PropertyType
-                    ? new KeyValuePair<string, object>(featureName, ConvertAttributeValue(shapeClass!, propertyInfo, value))
+                    ? new KeyValuePair<string, object>(featureName, ConvertAttributeValue(shapeClass, propertyInfo, value))
                     : new KeyValuePair<string, object>(featureName, value!);
             }
 
@@ -148,7 +148,7 @@ namespace MicroService.Service.Services.Base
 
         public string? GetFeatureName(string propertyName)
         {
-            TShape shapeClass = Activator.CreateInstance<TShape>();
+            TShape shapeClass = new();
             var featureName = ReflectionExtensions.GetAttributeFromProperty<FeatureNameAttribute>(shapeClass, propertyName);
 
             return featureName?.AttributeName;

--- a/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
+++ b/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
@@ -16,7 +16,7 @@ namespace MicroService.Test.Unit
         {
             const double value = 40.7128000005;
 
-            var result = _service.Match(value, 40.7128);
+            var result = TestShapeService.Match(value, 40.7128);
 
             Assert.Equal(value, result);
         }
@@ -24,7 +24,7 @@ namespace MicroService.Test.Unit
         [Fact]
         public void MatchAttributeValue_RejectsDoubleOutsideTolerance()
         {
-            var result = _service.Match(40.712800002, 40.7128);
+            var result = TestShapeService.Match(40.712800002, 40.7128);
 
             Assert.Null(result);
         }
@@ -35,7 +35,7 @@ namespace MicroService.Test.Unit
         [InlineData(42d, 43)]
         public void MatchAttributeValue_ReturnsNullForNumericMismatch(object value, object expectedValue)
         {
-            var result = _service.Match(value, expectedValue);
+            var result = TestShapeService.Match(value, expectedValue);
 
             Assert.Null(result);
         }
@@ -55,7 +55,7 @@ namespace MicroService.Test.Unit
             {
             }
 
-            public object? Match(object value, object expectedValue)
+            public static object? Match(object value, object expectedValue)
             {
                 return MatchAttributeValue(value, expectedValue);
             }


### PR DESCRIPTION
## Summary
- SonarQube flagged two `CRITICAL` findings (`csharpsquid:S3776`), the highest-severity real issues remaining after #491: `ValidateFeatureKey` at cognitive complexity 34 and `MatchAttributeValue` at 27, both against a limit of 15.
- Refactored both by extracting nested branches into focused private helper methods, which flattens the nesting depth that drives the complexity score:
  - `ValidateFeatureKey`: the per-attribute type-conversion `try`/`if`/`else if` chain moved into `ConvertAttributeValue` and `ConvertToPropertyType`, leaving the loop body as a single lookup + ternary.
  - `MatchAttributeValue`: rewritten as a `switch` expression dispatching to `MatchString`/`MatchInt`/`MatchDouble`, each a single flat comparison instead of nested `if`/`else if`.
- Both extracted match/convert helpers are `static` (they don't touch instance state), which also keeps them from tripping `CA1822` under the `.editorconfig` added in #491.

## Behavior preserved
- `MatchAttributeValue`: same type-pairing semantics for every branch (string-vs-string, int-vs-int, int-vs-double, double-vs-int, double-vs-double with `1e-9` tolerance), same fallthrough to `null` for every other type combination.
- `ValidateFeatureKey`: same conversion targets (`int`/`double`/`string`), same `FormatException`/`NotSupportedException` semantics on conversion failure, same early-`continue`-on-missing-property behavior (previously nested inside an `if`).

## Validation
- [x] `make check`
- [x] `make build`
- [x] `make test`
- [x] `make analyze`

Validation results:
- `make analyze`: 0 warnings, 0 errors.
- `make test`: 231 passed, 0 failed, 12 skipped (pre-existing, untouched) — includes the existing `MatchAttributeValue` unit tests (tolerance case, cross-type mismatch cases) and extensive `GetFeatureLookup` integration coverage across every shape service, which exercises `ValidateFeatureKey` indirectly.
- `make check` (pre-commit): all passed.

## Dependency / Stack Info
- Base branch: master
- Stack dependencies: None
- Related PRs: Follows #491 (analyzer/sonar gap fix, merged) — this addresses the two `CRITICAL` Sonar findings left after that PR.

## Known Risks
- `ValidateFeatureKey` has no direct unit test (only indirect coverage via `GetFeatureLookup` integration tests across shape services); the refactor preserves exact control flow and exception semantics by inspection, but a direct unit test would strengthen confidence for future changes.

## Review Follow-Up
- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness
- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist