### PR TITLE
fix: block auto-approve when Copilot leaves inline comments

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const maxAttempts = 30;
+            const initialDelayMs = 60000;
+            const maxAttempts = 24;
             const delayMs = 10000;
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
@@ -56,6 +57,9 @@ jobs:
                   run.conclusion === 'success'
               );
             };
+
+            core.info(`Waiting ${initialDelayMs / 1000}s before the first check — Copilot review consistently takes over a minute to appear`);
+            await new Promise(r => setTimeout(r, initialDelayMs));
 
             for (let i = 0; i < maxAttempts; i++) {
               const { data: reviews } = await github.rest.pulls.listReviews({

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -191,6 +191,23 @@ jobs:
               return;
             }
 
+            if (copilotReview) {
+              const comments = await github.paginate(github.rest.pulls.listReviewComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+
+              const copilotHeadComments = comments.filter(
+                c => c.user.login === 'copilot-pull-request-reviewer[bot]' && c.commit_id === headSha
+              );
+
+              if (copilotHeadComments.length > 0) {
+                core.setFailed(`Copilot left ${copilotHeadComments.length} inline comment(s) on the current head — not auto-approving`);
+                return;
+              }
+            }
+
             await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -69,7 +69,7 @@ jobs:
               });
 
               const copilotReview = reviews
-                .filter(r => r.user.login === 'copilot-pull-request-reviewer[bot]' && r.state !== 'DISMISSED' && r.commit_id === headSha)
+                .filter(r => r.user?.login === 'copilot-pull-request-reviewer[bot]' && r.state !== 'DISMISSED' && r.commit_id === headSha)
                 .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0];
 
               if (copilotReview) {
@@ -117,7 +117,7 @@ jobs:
             });
 
             const copilotReview = reviews
-              .filter(r => r.user.login === 'copilot-pull-request-reviewer[bot]' && r.state !== 'DISMISSED' && r.commit_id === headSha)
+              .filter(r => r.user?.login === 'copilot-pull-request-reviewer[bot]' && r.state !== 'DISMISSED' && r.commit_id === headSha)
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0];
 
             const copilotCheckSuccess = await hasCopilotCheckSuccessForHead();
@@ -134,7 +134,7 @@ jobs:
             });
 
             const copilotComments = comments.filter(
-              c => c.user.login === 'copilot-pull-request-reviewer[bot]'
+              c => c.user?.login === 'copilot-pull-request-reviewer[bot]'
             );
 
             core.info(`PR #${prNumber}: ${context.payload.pull_request.title}`);
@@ -180,7 +180,7 @@ jobs:
             });
 
             const copilotReview = reviews
-              .filter(r => r.user.login === 'copilot-pull-request-reviewer[bot]' && r.state !== 'DISMISSED' && r.commit_id === headSha)
+              .filter(r => r.user?.login === 'copilot-pull-request-reviewer[bot]' && r.state !== 'DISMISSED' && r.commit_id === headSha)
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0];
 
             const copilotCheckSuccess = await hasCopilotCheckSuccessForHead();
@@ -195,21 +195,19 @@ jobs:
               return;
             }
 
-            if (copilotReview) {
-              const comments = await github.paginate(github.rest.pulls.listReviewComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-              });
+            const comments = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
 
-              const copilotHeadComments = comments.filter(
-                c => c.user.login === 'copilot-pull-request-reviewer[bot]' && c.commit_id === headSha
-              );
+            const copilotHeadComments = comments.filter(
+              c => c.user?.login === 'copilot-pull-request-reviewer[bot]' && c.commit_id === headSha
+            );
 
-              if (copilotHeadComments.length > 0) {
-                core.setFailed(`Copilot left ${copilotHeadComments.length} inline comment(s) on the current head — not auto-approving`);
-                return;
-              }
+            if (copilotHeadComments.length > 0) {
+              core.setFailed(`Copilot left ${copilotHeadComments.length} inline comment(s) on the current head — not auto-approving`);
+              return;
             }
 
             await github.rest.pulls.createReview({


### PR DESCRIPTION
## Summary
- The "Auto approve after Copilot Review" job in `.github/workflows/auto-approve.yml` only refused to auto-approve when Copilot's review `state` was `CHANGES_REQUESTED`. In this repo, Copilot consistently reviews with state `COMMENTED` even when it leaves actionable inline findings — observed across #490, #491, and #492, every one of which got real, worth-fixing comments under a `COMMENTED` state. That guard therefore never actually fired: the job would wait for any review tied to the current head SHA and then approve, regardless of what it said.
- The existing "Log review context" step already computed the Copilot inline comment count and logged a `core.warning` — but nothing downstream acted on it, so the warning was purely informational.
- "Auto approve PR" now fails the job (instead of approving) whenever the current-head Copilot review has one or more inline comments still attached to that head SHA. This matches the manual workflow already in use on recent PRs: address feedback, push a fix commit, and only treat the PR as approvable once a fresh review on the new head comes back with zero comments.

## Validation
- [x] `make check`
- [ ] `make build`
- [ ] `make test`
- [ ] `make analyze`

Validation results:
- `make check` (pre-commit: yamllint, codespell, etc.): passed.
- `build`/`test`/`analyze` not applicable — no C#/.NET changes in this PR, workflow YAML only.
- Verified the new gate's logic by walking through each of #490/#491/#492's actual review history: in every case, the current change would have correctly blocked auto-approval at the commit that still had open Copilot comments, and allowed it only once a comment-free review landed on the fix commit.

## Dependency / Stack Info
- Base branch: master
- Stack dependencies: None
- Related PRs: Motivated by manually canceling a stuck Auto Approve run on #492 (workflow run 31024618277) that was waiting on a stale trigger point after a fix was pushed.

## Known Risks
- If Copilot ever changes its review-state semantics (e.g. starts using `CHANGES_REQUESTED` consistently), this additional comment-count check becomes redundant but not harmful — it's an additive safeguard, not a replacement for the existing state check.
- The check only looks at comments whose `commit_id` matches the current head SHA, consistent with how the rest of the workflow scopes "current" review state; comments left against older commits in the PR's history are correctly ignored.

## Review Follow-Up
- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness
- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist