### PR TITLE
fix: narrow MatchString return type to string?

### DIFF
--- a/src/MicroService.Service/Services/Base/AbstractShapeService.cs
+++ b/src/MicroService.Service/Services/Base/AbstractShapeService.cs
@@ -124,7 +124,7 @@ namespace MicroService.Service.Services.Base
             _ => null
         };
 
-        private static object? MatchString(string value, object expectedValue) =>
+        private static string? MatchString(string value, object expectedValue) =>
             expectedValue is string expected && value == expected ? value : null;
 
         private static object? MatchInt(int value, object expectedValue) => expectedValue switch


### PR DESCRIPTION
## Summary
- SonarQube (`external_roslyn:CA1859`) flagged `MatchString` in `AbstractShapeService.cs` returning `object?` when its actual return values are always `string?` — a regression introduced by #492's refactor of `MatchAttributeValue` into per-type helper methods.
- Narrowed `MatchString`'s declared return type to `string?`, avoiding unnecessary boxing/virtual dispatch. The calling `switch` expression in `MatchAttributeValue` still upcasts to `object?` as needed, since `MatchInt`/`MatchDouble` return boxed value types (`int`/`double`).

This is PR 1 of a stack fixing the fresh SonarQube scan's remaining findings (0 CRITICAL/BLOCKER now, thanks to the earlier complexity refactor — this PR closes the one new regression that refactor introduced).

## Validation
- [x] `make check`
- [x] `make build`
- [x] `make test`
- [x] `make analyze`

Validation results:
- `make analyze`: 0 warnings, 0 errors.
- `make test`: 231 passed, 0 failed, 12 skipped (pre-existing, untouched).
- `make check`: all hooks pass.

## Dependency / Stack Info
- Base branch: master
- Stack dependencies: None (base of stack)
- Related PRs: First in a stack addressing the fresh SonarQube scan (46 open issues, 0 critical/blocker) run after #491–496 merged.

## Known Risks
None.

## Review Follow-Up
- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness
- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist