### PR TITLE
feat: add gitleaks secret scanning to pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           curl --fail --location --retry 3 --silent --show-error \
             https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
             --output actionlint.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum --check --status
           tar -xzf actionlint.tar.gz actionlint
           rm -f actionlint.tar.gz
           echo "$PWD" >> "$GITHUB_PATH"
@@ -48,6 +49,7 @@ jobs:
           curl --fail --location --retry 3 --silent --show-error \
             https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
             --output gitleaks.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tar.gz" | sha256sum --check --status
           tar -xzf gitleaks.tar.gz gitleaks
           rm -f gitleaks.tar.gz
           echo "$PWD" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -40,6 +42,26 @@ jobs:
           tar -xzf actionlint.tar.gz actionlint
           rm -f actionlint.tar.gz
           echo "$PWD" >> "$GITHUB_PATH"
+
+      - name: Install gitleaks
+        run: |
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+            --output gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          rm -f gitleaks.tar.gz
+          echo "$PWD" >> "$GITHUB_PATH"
+
+      - name: Scan new commits for secrets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "${BASE_SHA}" || "${BASE_SHA}" =~ ^0+$ ]]; then
+            echo "No base commit available (e.g. first push to a new branch); scanning full history instead."
+            gitleaks git --redact --verbose --no-banner
+          else
+            gitleaks git --redact --verbose --no-banner --log-opts="${BASE_SHA}..HEAD"
+          fi
 
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,7 +7,4 @@ useDefault = true
 paths = [
   '''docfx/articles/myget\.md''',
   '''docfx/restapi/redoc\.standalone\.js''',
-  '''\.sonarqube/''',
-  '''\.test-results/''',
-  '''credentials/''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+title = "MicroService gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+paths = [
+  '''docfx/articles/myget\.md''',
+  '''docfx/restapi/redoc\.standalone\.js''',
+  '''\.sonarqube/''',
+  '''\.test-results/''',
+  '''credentials/''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,12 @@ repos:
         types: [yaml]
         files: ^\.github/workflows/
 
+      - id: gitleaks
+        name: gitleaks
+        entry: gitleaks git --pre-commit --redact --staged --verbose
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:

--- a/cspell.json
+++ b/cspell.json
@@ -76,6 +76,7 @@
     "desdate",
     "caldate",
     "developmen",
+    "dgst",
     "districtco",
     "docfx",
     "dockerfile",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -257,7 +257,7 @@ install_actionlint() {
     log "Installing actionlint ${ACTIONLINT_VERSION}"
     curl --fail --location --retry 3 --silent --show-error "${url}" --output "${archive}"
 
-    actual_checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+    actual_checksum="$(openssl dgst -sha256 -r "${archive}" | awk '{print $1}')"
     [[ "${actual_checksum}" == "${expected_checksum}" ]] \
         || fail "Checksum mismatch for ${asset_name}: expected ${expected_checksum}, got ${actual_checksum}"
 
@@ -329,7 +329,7 @@ install_gitleaks() {
     log "Installing gitleaks ${GITLEAKS_VERSION}"
     curl --fail --location --retry 3 --silent --show-error "${url}" --output "${archive}"
 
-    actual_checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+    actual_checksum="$(openssl dgst -sha256 -r "${archive}" | awk '{print $1}')"
     [[ "${actual_checksum}" == "${expected_checksum}" ]] \
         || fail "Checksum mismatch for ${asset_name}: expected ${expected_checksum}, got ${actual_checksum}"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,6 +14,8 @@ readonly PRE_COMMIT_ENV="${HOME}/.local/share/MicroService/pre-commit"
 readonly SONAR_SCANNER_VERSION="11.2.1"
 readonly ACTIONLINT_VERSION="1.7.12"
 readonly ACTIONLINT_INSTALL_DIR="${HOME}/.local/bin"
+readonly GITLEAKS_VERSION="8.30.1"
+readonly GITLEAKS_INSTALL_DIR="${HOME}/.local/bin"
 
 log() {
     printf '[setup] %s\n' "$*"
@@ -243,6 +245,56 @@ install_actionlint() {
     rm -rf -- "${temp_dir}"
 }
 
+gitleaks_asset_name() {
+    local os arch
+
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "${os}" in
+        Linux) os="linux" ;;
+        Darwin) os="darwin" ;;
+        *) fail "Unsupported operating system for gitleaks: ${os}" ;;
+    esac
+
+    case "${arch}" in
+        x86_64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *) fail "Unsupported architecture for gitleaks: ${arch}" ;;
+    esac
+
+    printf 'gitleaks_%s_%s_%s.tar.gz\n' "${GITLEAKS_VERSION}" "${os}" "${arch}"
+}
+
+install_gitleaks() {
+    local gitleaks_bin="${GITLEAKS_INSTALL_DIR}/gitleaks"
+    local installed_version
+    local asset_name temp_dir archive url
+
+    export PATH="${GITLEAKS_INSTALL_DIR}:${PATH}"
+
+    if [[ -x "${gitleaks_bin}" ]]; then
+        installed_version="$("${gitleaks_bin}" version 2>/dev/null | head -n 1)"
+        if [[ "${installed_version}" == *"${GITLEAKS_VERSION}"* ]]; then
+            log "gitleaks ${GITLEAKS_VERSION} is already installed"
+            return
+        fi
+    fi
+
+    asset_name="$(gitleaks_asset_name)"
+    url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset_name}"
+    temp_dir="$(mktemp -d)"
+    archive="${temp_dir}/${asset_name}"
+
+    log "Installing gitleaks ${GITLEAKS_VERSION}"
+    curl --fail --location --retry 3 --silent --show-error "${url}" --output "${archive}"
+
+    mkdir -p "${GITLEAKS_INSTALL_DIR}"
+    tar -xzf "${archive}" -C "${temp_dir}" gitleaks
+    install -m 755 "${temp_dir}/gitleaks" "${gitleaks_bin}"
+    rm -rf -- "${temp_dir}"
+}
+
 verify_toolchain() {
     local expected_sdk="$1"
     local actual_sdk
@@ -255,6 +307,7 @@ verify_toolchain() {
     log "Make: $(make --version | head -n 1)"
     log "ShellCheck: $(shellcheck --version | sed -n 's/^version: //p')"
     log "actionlint: $(actionlint -version | head -n 1)"
+    log "gitleaks: $(gitleaks version)"
 
     if command -v docker >/dev/null 2>&1; then
         log "Docker: $(docker --version)"
@@ -292,6 +345,7 @@ main() {
     install_dotnet_sdk "${sdk_version}"
     install_sonar_scanner
     install_actionlint
+    install_gitleaks
     install_pre_commit
     verify_toolchain "${sdk_version}"
     repair_generated_artifact_permissions

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -216,10 +216,27 @@ actionlint_asset_name() {
     printf 'actionlint_%s_%s_%s.tar.gz\n' "${ACTIONLINT_VERSION}" "${os}" "${arch}"
 }
 
+actionlint_asset_checksum() {
+    local asset_name="$1"
+
+    case "${asset_name}" in
+        actionlint_1.7.12_linux_amd64.tar.gz)
+            printf '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8\n' ;;
+        actionlint_1.7.12_linux_arm64.tar.gz)
+            printf '325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6\n' ;;
+        actionlint_1.7.12_darwin_amd64.tar.gz)
+            printf '5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644\n' ;;
+        actionlint_1.7.12_darwin_arm64.tar.gz)
+            printf 'aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f\n' ;;
+        *)
+            fail "No pinned checksum for actionlint asset: ${asset_name}" ;;
+    esac
+}
+
 install_actionlint() {
     local actionlint_bin="${ACTIONLINT_INSTALL_DIR}/actionlint"
     local installed_version
-    local asset_name temp_dir archive url
+    local asset_name temp_dir archive url expected_checksum actual_checksum
 
     export PATH="${ACTIONLINT_INSTALL_DIR}:${PATH}"
 
@@ -232,12 +249,17 @@ install_actionlint() {
     fi
 
     asset_name="$(actionlint_asset_name)"
+    expected_checksum="$(actionlint_asset_checksum "${asset_name}")"
     url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${asset_name}"
     temp_dir="$(mktemp -d)"
     archive="${temp_dir}/${asset_name}"
 
     log "Installing actionlint ${ACTIONLINT_VERSION}"
     curl --fail --location --retry 3 --silent --show-error "${url}" --output "${archive}"
+
+    actual_checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+    [[ "${actual_checksum}" == "${expected_checksum}" ]] \
+        || fail "Checksum mismatch for ${asset_name}: expected ${expected_checksum}, got ${actual_checksum}"
 
     mkdir -p "${ACTIONLINT_INSTALL_DIR}"
     tar -xzf "${archive}" -C "${temp_dir}" actionlint
@@ -266,10 +288,27 @@ gitleaks_asset_name() {
     printf 'gitleaks_%s_%s_%s.tar.gz\n' "${GITLEAKS_VERSION}" "${os}" "${arch}"
 }
 
+gitleaks_asset_checksum() {
+    local asset_name="$1"
+
+    case "${asset_name}" in
+        gitleaks_8.30.1_linux_x64.tar.gz)
+            printf '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb\n' ;;
+        gitleaks_8.30.1_linux_arm64.tar.gz)
+            printf 'e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080\n' ;;
+        gitleaks_8.30.1_darwin_x64.tar.gz)
+            printf 'dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709\n' ;;
+        gitleaks_8.30.1_darwin_arm64.tar.gz)
+            printf 'b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5\n' ;;
+        *)
+            fail "No pinned checksum for gitleaks asset: ${asset_name}" ;;
+    esac
+}
+
 install_gitleaks() {
     local gitleaks_bin="${GITLEAKS_INSTALL_DIR}/gitleaks"
     local installed_version
-    local asset_name temp_dir archive url
+    local asset_name temp_dir archive url expected_checksum actual_checksum
 
     export PATH="${GITLEAKS_INSTALL_DIR}:${PATH}"
 
@@ -282,12 +321,17 @@ install_gitleaks() {
     fi
 
     asset_name="$(gitleaks_asset_name)"
+    expected_checksum="$(gitleaks_asset_checksum "${asset_name}")"
     url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset_name}"
     temp_dir="$(mktemp -d)"
     archive="${temp_dir}/${asset_name}"
 
     log "Installing gitleaks ${GITLEAKS_VERSION}"
     curl --fail --location --retry 3 --silent --show-error "${url}" --output "${archive}"
+
+    actual_checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+    [[ "${actual_checksum}" == "${expected_checksum}" ]] \
+        || fail "Checksum mismatch for ${asset_name}: expected ${expected_checksum}, got ${actual_checksum}"
 
     mkdir -p "${GITLEAKS_INSTALL_DIR}"
     tar -xzf "${archive}" -C "${temp_dir}" gitleaks


### PR DESCRIPTION
## Summary
Recreates #500, which GitHub auto-closed when `master`'s history was rewritten (see below) — the branch and its content are unchanged, just resubmitted against the new history.

Adds [gitleaks](https://github.com/gitleaks/gitleaks) (pinned v8.30.1) to catch hardcoded secrets before they merge — prompted by two near-misses this session: a GCP service account key that got pasted directly into chat, and locally-set database credentials via `dotnet user-secrets`.

- `scripts/setup.sh`: installs the pinned gitleaks release binary into `~/.local/bin`, following the same download/verify/idempotent pattern as `install_actionlint`. Reported in `verify_toolchain`.
- `.pre-commit-config.yaml`: added a gitleaks local hook using upstream's official `gitleaks-system` invocation (`gitleaks git --pre-commit --redact --staged --verbose`), which scans only the staged diff.
- `.gitleaks.toml`: extends gitleaks' default ruleset with an allowlist scoped to exactly two known false-positive files — a documented example API key in `docfx/articles/myget.md`, and vendored/minified third-party JS (`docfx/restapi/redoc.standalone.js`). Generated/gitignored directories (`.sonarqube/`, `.test-results/`, `credentials/`) are deliberately *not* allowlisted — see the Copilot review follow-up below.
- `.github/workflows/ci.yml`: added a dedicated step that diffs only the commits introduced by the current push or PR (via `--log-opts`), since the pre-commit hook's `--staged` mode is a no-op in a CI checkout.
- Both `scripts/setup.sh`'s and `ci.yml`'s gitleaks/actionlint install steps now verify the downloaded archive's SHA256 checksum before extracting it (pinned per OS/arch from each tool's published `*_checksums.txt`), added during review — a security-scanning tool downloading and executing an unverified binary was worth closing before merge.

## Why master's history changed
Running the original PR's CI (after a manual `workflow_dispatch`, since the `pull_request` trigger had a one-off scheduling gap) surfaced real historical secrets going back to 2019–2023: a SonarQube token, two Sonar project keys, three Slack webhook URLs, and a self-signed TLS private key — all committed to old, since-superseded files (`sonar.bat`, `build/settings.cake`, `appsettings.json`, `docker/nginx/ssl/localhost.key`). These were purged from `master` and all branches via `git filter-repo`, verified with an independent `gitleaks` re-scan, `git fsck`, and a clean `make analyze` build from the rewritten history, then force-pushed. (GitHub's own `refs/pull/N/head` snapshot refs are immutable and still contain a handful of these old values in ~60 old PR refs — not reachable from any branch, accepted as residual given the age and likely-defunct status of those services.)

## Validation
- [x] `make check`
- [ ] `make build`
- [ ] `make test`
- [ ] `make analyze`

Validation results: unchanged from the original PR — `make check` (including the new `gitleaks` hook) passes clean; verified end-to-end with a throwaway secret commit that both the pre-commit hook and the CI-style commit-range scan catch and block it.

## Dependency / Stack Info
- Base branch: master
- Stack dependencies: None
- Related PRs: Recreates #500 (auto-closed by GitHub due to the master history rewrite described above)

## Review Follow-Up
- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness
- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist
