### PR TITLE
test: close MicroService.Service.dll coverage gaps to 98.6%

### DIFF
--- a/test/MicroService.Test/Fixture/ShapeServiceFixture.cs
+++ b/test/MicroService.Test/Fixture/ShapeServiceFixture.cs
@@ -11,6 +11,7 @@ using MicroService.Service.Services.Base;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace MicroService.Test.Fixture
@@ -21,7 +22,7 @@ namespace MicroService.Test.Fixture
         {
             var serviceProvider = new ServiceCollection()
                 .AddMemoryCache()
-                .AddLogging()
+                .AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information))
                 .AddScoped<ShapefileDataReaderResolver>(serviceProvider => key =>
                 {
                     ShapeAttribute shapeProperties = null!;

--- a/test/MicroService.Test/Functions/EnumHelperTest.cs
+++ b/test/MicroService.Test/Functions/EnumHelperTest.cs
@@ -100,5 +100,50 @@ namespace MicroService.Test.Functions
             // Act & Assert
             Assert.Throws<ArgumentException>(() => EnumHelper.EnumToList<ShapeBase>());
         }
+
+        [Fact]
+        public void GetAttribute_ThrowsArgumentException_WhenMemberHasNoMatchingAttribute()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => NoAttributeEnum.Value.GetAttribute<FeatureNameAttribute>());
+        }
+
+        [Fact]
+        public void GetEnumDescription_ReturnsEnumName_WhenNoDescriptionAttributePresent()
+        {
+            // Act
+            var result = NoAttributeEnum.Value.GetEnumDescription();
+
+            // Assert
+            Assert.Equal(nameof(NoAttributeEnum.Value), result);
+        }
+
+        [Fact]
+        public void GetValueFromDescription_FallsBackToFieldName_WhenNoDescriptionAttributePresent()
+        {
+            // Act
+            var result = EnumHelper.GetValueFromDescription<NoAttributeEnum>(nameof(NoAttributeEnum.Value));
+
+            // Assert
+            Assert.Equal(NoAttributeEnum.Value, result);
+        }
+
+        [Fact]
+        public void GetEnumDescription_ReturnsToString_WhenValueIsNotADefinedMember()
+        {
+            // Arrange: an undefined enum value has no backing field to reflect over.
+            var undefined = (NoAttributeEnum)999;
+
+            // Act
+            var result = undefined.GetEnumDescription();
+
+            // Assert
+            Assert.Equal(undefined.ToString(), result);
+        }
+
+        private enum NoAttributeEnum
+        {
+            Value
+        }
     }
 }

--- a/test/MicroService.Test/Functions/ReflectionExtensionsTest.cs
+++ b/test/MicroService.Test/Functions/ReflectionExtensionsTest.cs
@@ -85,6 +85,16 @@ namespace MicroService.Test.Functions
         }
 
         [Fact]
+        public void GetAttributeFromProperty_PropertyDoesNotExist_ThrowsArgumentException()
+        {
+            // Arrange
+            var obj = new TestObjectWithAttribute();
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ReflectionExtensions.GetAttributeFromProperty<MyCustomAttribute>(obj, "NotAProperty"));
+        }
+
+        [Fact]
         public void GetPropertiesWithCustomAttribute_TypeHasPropertiesWithAttribute_ReturnsPropertiesWithAttribute()
         {
             // Arrange
@@ -110,6 +120,19 @@ namespace MicroService.Test.Functions
 
             // Assert
             Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetPropertiesWithCustomAttribute_ReturnsPropertyDecoratedWithMappingKeyAttribute()
+        {
+            // Arrange
+            var type = typeof(MicroService.Service.Models.IndividualLandmarkHistoricDistrictsShape);
+
+            // Act
+            var result = type.GetPropertiesWithCustomAttribute<MicroService.Service.Models.Enum.Attributes.MappingKeyAttribute>();
+
+            // Assert
+            Assert.Contains(result, p => p.Name == nameof(MicroService.Service.Models.IndividualLandmarkHistoricDistrictsShape.LPNumber));
         }
     }
 

--- a/test/MicroService.Test/Integration/BoroughBoundariesServiceTest.cs
+++ b/test/MicroService.Test/Integration/BoroughBoundariesServiceTest.cs
@@ -161,9 +161,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
     }
 }

--- a/test/MicroService.Test/Integration/CommunityDistrictServiceTest.cs
+++ b/test/MicroService.Test/Integration/CommunityDistrictServiceTest.cs
@@ -141,9 +141,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
     }
 }

--- a/test/MicroService.Test/Integration/DsnyDistrictsServiceTest.cs
+++ b/test/MicroService.Test/Integration/DsnyDistrictsServiceTest.cs
@@ -145,9 +145,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
     }
 }

--- a/test/MicroService.Test/Integration/HistoricDistrictServiceTest.cs
+++ b/test/MicroService.Test/Integration/HistoricDistrictServiceTest.cs
@@ -142,9 +142,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
     }
 }

--- a/test/MicroService.Test/Integration/IndividualLandmarkHistoricDistrictsTest.cs
+++ b/test/MicroService.Test/Integration/IndividualLandmarkHistoricDistrictsTest.cs
@@ -207,8 +207,26 @@ namespace MicroService.Test.Integration
         [Fact(DisplayName = "Get Feature List")]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
+        }
+
+        [InlineData("LP-99999")]
+        [Theory(DisplayName = "GetFeatureCollection Mapped Input returns null when no landmark site matches")]
+        public void GetFeatureCollection_Mapped_UnknownLPNumber_ReturnsNull(string value1)
+        {
+            // Arrange
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("LPNumber", value1),
+            };
+
+            // Act
+            var sut = _service.GetFeatureCollection(attributes);
+
+            // Assert
+            Assert.Null(sut);
         }
 
     }

--- a/test/MicroService.Test/Integration/IndividualLandmarkSiteServiceTest.cs
+++ b/test/MicroService.Test/Integration/IndividualLandmarkSiteServiceTest.cs
@@ -63,8 +63,9 @@ namespace MicroService.Test.Integration
         [Fact(DisplayName = "Get Feature List")]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
 
         [InlineData(987615.655217366, 211953.9590513381, "Hotel Martinique", "MN")]

--- a/test/MicroService.Test/Integration/NationalRegisterHistoricPlacesTest.cs
+++ b/test/MicroService.Test/Integration/NationalRegisterHistoricPlacesTest.cs
@@ -150,9 +150,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
     }
 }

--- a/test/MicroService.Test/Integration/NeighborhoodServiceTest.cs
+++ b/test/MicroService.Test/Integration/NeighborhoodServiceTest.cs
@@ -141,9 +141,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
 
     }

--- a/test/MicroService.Test/Integration/NeighborhoodTabulationAreasTest.cs
+++ b/test/MicroService.Test/Integration/NeighborhoodTabulationAreasTest.cs
@@ -135,8 +135,9 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
+            Assert.NotEmpty(sut);
             Assert.NotNull(sut);
         }
 

--- a/test/MicroService.Test/Integration/NychaDevelopmentTest.cs
+++ b/test/MicroService.Test/Integration/NychaDevelopmentTest.cs
@@ -137,8 +137,9 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
+            Assert.NotEmpty(sut);
             Assert.NotNull(sut);
         }
     }

--- a/test/MicroService.Test/Integration/NypdPolicePrecinctServiceTest.cs
+++ b/test/MicroService.Test/Integration/NypdPolicePrecinctServiceTest.cs
@@ -116,9 +116,30 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
+        }
+
+        [InlineData("14")]
+        [Theory(DisplayName = "GetFeatureCollection returns a feature collection")]
+        public void GetFeatureCollection_ValidInput_ReturnsFeatureCollection(string value1)
+        {
+            // Arrange
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("Precinct", int.Parse(value1)),
+            };
+
+            // Act
+            var sut = _service.GetFeatureCollection(attributes);
+
+            // Assert
+            var collection = Assert.IsType<FeatureCollection>(sut);
+            Assert.NotEmpty(collection);
+            Assert.All(collection, feature =>
+                Assert.Equal(int.Parse(value1), Assert.IsType<int>(feature.Attributes["Precinct"])));
         }
     }
 }

--- a/test/MicroService.Test/Integration/NypdSectorsServiceTest.cs
+++ b/test/MicroService.Test/Integration/NypdSectorsServiceTest.cs
@@ -142,8 +142,9 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
+            Assert.NotEmpty(sut);
             Assert.NotNull(sut);
         }
     }

--- a/test/MicroService.Test/Integration/ParkServiceTest.cs
+++ b/test/MicroService.Test/Integration/ParkServiceTest.cs
@@ -144,9 +144,10 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
             Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
         }
 
 

--- a/test/MicroService.Test/Integration/ScenicLandmarkServiceTest.cs
+++ b/test/MicroService.Test/Integration/ScenicLandmarkServiceTest.cs
@@ -178,8 +178,9 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
+            Assert.NotEmpty(sut);
             Assert.NotNull(sut);
         }
 

--- a/test/MicroService.Test/Integration/SubwayServiceTest.cs
+++ b/test/MicroService.Test/Integration/SubwayServiceTest.cs
@@ -155,8 +155,9 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
+            Assert.NotEmpty(sut);
             Assert.NotNull(sut);
         }
 

--- a/test/MicroService.Test/Integration/ZipCodeServiceTest.cs
+++ b/test/MicroService.Test/Integration/ZipCodeServiceTest.cs
@@ -147,8 +147,9 @@ namespace MicroService.Test.Integration
         [Fact]
         public void Get_Feature_List()
         {
-            var sut = _service.GetFeatureList();
+            var sut = _service.GetFeatureList().ToList();
 
+            Assert.NotEmpty(sut);
             Assert.NotNull(sut);
         }
     }

--- a/test/MicroService.Test/Mappings/Base/ShapeProfileTest.cs
+++ b/test/MicroService.Test/Mappings/Base/ShapeProfileTest.cs
@@ -1,0 +1,80 @@
+using MicroService.Service.Mappings.Base;
+using MicroService.Service.Models.Base;
+using NetTopologySuite.Features;
+using Xunit;
+
+namespace MicroService.Test.Mappings.Base
+{
+    public class ShapeProfileTest
+    {
+        private sealed class TestShapeProfile : ShapeProfile<ShapeBase>
+        {
+            public static string CallGetString(Feature src, string key) => GetString(src, key);
+
+            public static double CallGetDouble(Feature src, string key) => GetDouble(src, key);
+
+            public static string? CallGetSanitizedString(Feature src, string key) => GetSanitizedString(src, key);
+        }
+
+        [Fact]
+        public void GetString_ReturnsEmpty_WhenAttributeIsNull()
+        {
+            var feature = new Feature(null, new AttributesTable(new Dictionary<string, object?> { { "key", null } }!));
+
+            var result = TestShapeProfile.CallGetString(feature, "key");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void GetString_ReturnsValue_WhenAttributeIsPresent()
+        {
+            var feature = new Feature(null, new AttributesTable(new Dictionary<string, object> { { "key", "value" } }));
+
+            var result = TestShapeProfile.CallGetString(feature, "key");
+
+            Assert.Equal("value", result);
+        }
+
+        [Fact]
+        public void GetDouble_ReturnsZero_WhenAttributeIsNull()
+        {
+            var feature = new Feature(null, new AttributesTable(new Dictionary<string, object?> { { "key", null } }!));
+
+            var result = TestShapeProfile.CallGetDouble(feature, "key");
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void GetDouble_ReturnsParsedValue_WhenAttributeIsPresent()
+        {
+            var feature = new Feature(null, new AttributesTable(new Dictionary<string, object> { { "key", "12.5" } }));
+
+            var result = TestShapeProfile.CallGetDouble(feature, "key");
+
+            Assert.Equal(12.5, result);
+        }
+
+        [Fact]
+        public void GetSanitizedString_ReturnsNull_WhenAttributeIsNull()
+        {
+            var feature = new Feature(null, new AttributesTable(new Dictionary<string, object?> { { "key", null } }!));
+
+            var result = TestShapeProfile.CallGetSanitizedString(feature, "key");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetSanitizedString_StripsNullCharacters()
+        {
+            var value = "abc" + '\u0000' + "def";
+            var feature = new Feature(null, new AttributesTable(new Dictionary<string, object> { { "key", value } }));
+
+            var result = TestShapeProfile.CallGetSanitizedString(feature, "key");
+
+            Assert.Equal("abcdef", result);
+        }
+    }
+}

--- a/test/MicroService.Test/Mappings/IndividualLandmarkSiteShapeProfileTest.cs
+++ b/test/MicroService.Test/Mappings/IndividualLandmarkSiteShapeProfileTest.cs
@@ -1,0 +1,59 @@
+using AutoMapper;
+using MicroService.Service.Mappings;
+using MicroService.Service.Models;
+using MicroService.Test.Mappings.Base;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using Xunit;
+
+namespace MicroService.Test.Mappings
+{
+    public class IndividualLandmarkSiteShapeProfileTest : BaseMapper<IndividualLandmarkSiteShape>
+    {
+        private static Feature BuildFeature(object? alternativeName)
+        {
+            var attributes = new Dictionary<string, object?>
+            {
+                { "lpc_lpnumb", "LP-00001" },
+                { "lpc_name", "Test Landmark" },
+                { "borough", "MN" },
+                { "bbl", "1000010001" },
+                { "address", "1 Test Street" },
+                { "block", "1" },
+                { "lot", "1" },
+                { "objectid", "1" },
+                { "date_des_d", "2000-01-01" },
+                { "lpc_altern", alternativeName },
+                { "lpc_site_d", "Individual Landmark" },
+                { "landmark_t", "Individual Landmark" },
+                { "lpc_site_s", "Designated" },
+                { "url_report", "http://example.com" },
+                { "shape_area", "1.0" },
+                { "shape_leng", "1.0" },
+            };
+
+            return new Feature(new Point(0, 0), new AttributesTable(attributes!));
+        }
+
+        [Fact]
+        public void Map_ReturnsNullAlternativeName_WhenAttributeIsAbsent()
+        {
+            var feature = BuildFeature(null);
+
+            var shape = Mapper.Map<IndividualLandmarkSiteShape>(feature);
+
+            Assert.Null(shape.AlternativeName);
+        }
+
+        [Fact]
+        public void Map_StripsNullCharacters_FromAlternativeName()
+        {
+            var value = "Old" + '\u0000' + "Name";
+            var feature = BuildFeature(value);
+
+            var shape = Mapper.Map<IndividualLandmarkSiteShape>(feature);
+
+            Assert.Equal("OldName", shape.AlternativeName);
+        }
+    }
+}

--- a/test/MicroService.Test/Mock/CalculationServiceMock.cs
+++ b/test/MicroService.Test/Mock/CalculationServiceMock.cs
@@ -37,6 +37,12 @@ namespace MicroService.Test.Mock
             Assert.Equal(result, sut);
         }
 
+        [Fact]
+        public void Constructor_ThrowsArgumentNullException_WhenRepositoryIsNull()
+        {
+            Assert.Throws<System.ArgumentNullException>(() => new CalculationService(null!));
+        }
+
         private static CalculationService GetCalculationService(ITestDataRepository? testDataRepository = null)
         {
             testDataRepository ??= new Mock<ITestDataRepository>().Object;

--- a/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
+++ b/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
@@ -41,6 +41,22 @@ namespace MicroService.Test.Unit
         }
 
         [Fact]
+        public void MatchAttributeValue_MatchesIntAgainstEqualInt()
+        {
+            var result = TestShapeService.Match(42, 42);
+
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public void MatchAttributeValue_MatchesIntAgainstEqualDouble()
+        {
+            var result = TestShapeService.Match(42, 42d);
+
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
         public void GetFeatureLookup_ReturnsEmptySequenceForNullAttributes()
         {
             var result = _service.GetFeatureLookup(null);
@@ -48,10 +64,162 @@ namespace MicroService.Test.Unit
             Assert.Empty(result);
         }
 
+        [Fact]
+        public void Constructor_ThrowsArgumentNullException_WhenLoggerIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TestShapeService(logger: null!, mapper: Moq.Mock.Of<IMapper>()));
+        }
+
+        [Fact]
+        public void Constructor_ThrowsArgumentNullException_WhenMapperIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TestShapeService(logger: Moq.Mock.Of<ILogger>(), mapper: null!));
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ReturnsNull_ForNullAttributes()
+        {
+            var result = _service.ValidateFeatureKey(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_SkipsUnknownProperty()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("NotARealProperty", "value"),
+            };
+
+            var result = _service.ValidateFeatureKey(attributes);
+
+            Assert.NotNull(result);
+            Assert.Equal("NotARealProperty", result[0].Key);
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ConvertsMismatchedIntValue()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("BoroCode", "205"),
+            };
+
+            var result = _service.ValidateFeatureKey(attributes);
+
+            Assert.NotNull(result);
+            Assert.Equal(205, result[0].Value);
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_KeepsValueUnchanged_WhenTypeAlreadyMatches()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("BoroCode", 205),
+            };
+
+            var result = _service.ValidateFeatureKey(attributes);
+
+            Assert.NotNull(result);
+            Assert.Equal(205, result[0].Value);
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ConvertsMismatchedDoubleValue()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("ShapeArea", "12.5"),
+            };
+
+            var result = _service.ValidateFeatureKey(attributes);
+
+            Assert.NotNull(result);
+            Assert.Equal(12.5, result[0].Value);
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ThrowsNotSupportedException_WhenTargetTypeIsUnsupported()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("BoundingBox", "not-a-bounding-box"),
+            };
+
+            Assert.Throws<NotSupportedException>(() => _service.ValidateFeatureKey(attributes));
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ConvertsMismatchedStringValue()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("BoroName", 42),
+            };
+
+            var result = _service.ValidateFeatureKey(attributes);
+
+            Assert.NotNull(result);
+            Assert.Equal("42", result[0].Value);
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ThrowsFormatException_WhenIntConversionFails()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("BoroCode", "not-a-number"),
+            };
+
+            Assert.Throws<FormatException>(() => _service.ValidateFeatureKey(attributes));
+        }
+
+        [Fact]
+        public void ValidateFeatureKey_ThrowsFormatException_WhenDoubleConversionFails()
+        {
+            var attributes = new List<KeyValuePair<string, object>>
+            {
+                new("ShapeArea", "not-a-number"),
+            };
+
+            Assert.Throws<FormatException>(() => _service.ValidateFeatureKey(attributes));
+        }
+
+        [Fact]
+        public void GetFeatureName_ReturnsNull_WhenPropertyHasNoFeatureNameAttribute()
+        {
+            var result = _service.GetFeatureName(nameof(BoroughBoundaryShape.ShapeArea));
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void MatchAttributeValue_ReturnsNull_WhenIntComparedAgainstNonNumericExpectedValue()
+        {
+            var result = TestShapeService.Match(1, "not-a-number");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void MatchAttributeValue_ReturnsNull_WhenDoubleComparedAgainstNonNumericExpectedValue()
+        {
+            var result = TestShapeService.Match(1.5, "not-a-number");
+
+            Assert.Null(result);
+        }
+
         private sealed class TestShapeService : AbstractShapeService<BoroughBoundaryShape, BoroughBoundaryShapeProfile>
         {
             public TestShapeService()
                 : base(Moq.Mock.Of<ILogger>(), Moq.Mock.Of<IMapper>())
+            {
+            }
+
+            public TestShapeService(ILogger logger, IMapper mapper)
+                : base(logger, mapper)
             {
             }
 

--- a/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
+++ b/test/MicroService.Test/Unit/AbstractShapeServiceTest.cs
@@ -85,7 +85,7 @@ namespace MicroService.Test.Unit
         }
 
         [Fact]
-        public void ValidateFeatureKey_SkipsUnknownProperty()
+        public void ValidateFeatureKey_LeavesUnknownPropertyUnchanged()
         {
             var attributes = new List<KeyValuePair<string, object>>
             {

--- a/test/MicroService.Test/Unit/BoundingBoxTest.cs
+++ b/test/MicroService.Test/Unit/BoundingBoxTest.cs
@@ -1,0 +1,24 @@
+using MicroService.Service.Models.Base;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class BoundingBoxTest
+    {
+        [Fact]
+        public void Width_ReturnsDifferenceBetweenMaxAndMinX()
+        {
+            var box = new BoundingBox { MinX = 10, MaxX = 25 };
+
+            Assert.Equal(15, box.Width);
+        }
+
+        [Fact]
+        public void Height_ReturnsDifferenceBetweenMaxAndMinY()
+        {
+            var box = new BoundingBox { MinY = 5, MaxY = 30 };
+
+            Assert.Equal(25, box.Height);
+        }
+    }
+}

--- a/test/MicroService.Test/Unit/FunctionHelperUnitTest.cs
+++ b/test/MicroService.Test/Unit/FunctionHelperUnitTest.cs
@@ -229,6 +229,34 @@ namespace MicroService.Test.Unit
             Assert.Empty(result);
         }
 
+        [Fact]
+        public void Percentile_AtMaximum_ReturnsLastElement_WithoutInterpolation()
+        {
+            var result = FunctionHelper.Percentile(new double[] { 1, 2, 3, 4 }, 1.0);
+
+            Assert.Equal(4, result);
+        }
+
+        [Fact]
+        public void ConvertWgs84ToNad83_Array_ThrowsArgumentException_WhenInputHasIncorrectLength()
+        {
+            // Arrange
+            double[] point = { 1.0, 2.0, 3.0 };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => GeoTransformationHelper.ConvertWgs84ToNad83(point));
+        }
+
+        [Fact]
+        public void TransformGeometry_ThrowsArgumentException_ForInvalidDatumCombination()
+        {
+            // Arrange
+            var point = new Point(-73.8832294373166, 40.681939660888951);
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => GeoTransformationHelper.TransformGeometry(point, Datum.Nad83, Datum.Nad83));
+        }
+
 
         [InlineData(40.681939660888951, -73.8832294373166, 187747.0294683996, 1016636.9999607186)]
         [Theory]

--- a/test/MicroService.Test/Unit/ShapeConfigurationTest.cs
+++ b/test/MicroService.Test/Unit/ShapeConfigurationTest.cs
@@ -1,0 +1,27 @@
+using MicroService.Service.Configuration;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class ShapeConfigurationTest
+    {
+        [Fact]
+        public void ShapeSystemRootDirectory_ReturnsNull_WhenShapeRootDirectoryIsNull()
+        {
+            var config = new ShapeConfiguration();
+
+            Assert.Null(config.ShapeSystemRootDirectory);
+        }
+
+        [Fact]
+        public void ShapeSystemRootDirectory_ReturnsFullPath_WhenShapeRootDirectoryIsSet()
+        {
+            var config = new ShapeConfiguration { ShapeRootDirectory = "files" };
+
+            var result = config.ShapeSystemRootDirectory;
+
+            Assert.NotNull(result);
+            Assert.True(Path.IsPathRooted(result));
+        }
+    }
+}

--- a/test/MicroService.Test/Unit/StationComplexFlatFileServiceTest.cs
+++ b/test/MicroService.Test/Unit/StationComplexFlatFileServiceTest.cs
@@ -1,0 +1,21 @@
+using MicroService.Service.Models.FlatFileModels;
+using MicroService.Service.Services.FlatFileService;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class StationComplexFlatFileServiceTest
+    {
+        [Fact]
+        public void GetAll_ReturnsStationComplexRecords()
+        {
+            var service = new StationComplexFlatFileService();
+
+            var sut = service.GetAll().ToList();
+
+            Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
+            Assert.All(sut, item => Assert.IsType<StationComplexFlatFile>(item));
+        }
+    }
+}

--- a/test/MicroService.Test/Unit/StationFlatFileServiceTest.cs
+++ b/test/MicroService.Test/Unit/StationFlatFileServiceTest.cs
@@ -1,0 +1,21 @@
+using MicroService.Service.Models.FlatFileModels;
+using MicroService.Service.Services.FlatFileService;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class StationFlatFileServiceTest
+    {
+        [Fact]
+        public void GetAll_ReturnsStationRecords()
+        {
+            var service = new StationFlatFileService();
+
+            var sut = service.GetAll().ToList();
+
+            Assert.NotNull(sut);
+            Assert.NotEmpty(sut);
+            Assert.All(sut, item => Assert.IsType<StationFlatFile>(item));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the SonarQube new-coverage gap for `MicroService.Service.dll`, going from 89.1% to 98.6% line coverage.
- Fixes a shared test-fixture bug (`ShapeServiceFixture`): `.AddLogging()` had no provider attached, so `Logger.IsEnabled(LogLevel.Information)` always returned `false`, permanently skipping logged branches in several `GetFeatureList()` implementations. Switched to `AddConsole()` + `SetMinimumLevel(Information)`.
- Fixes ~10 integration tests across shape services that called `GetFeatureList()` without enumerating the lazily-evaluated `IEnumerable<T>` result, so the underlying `OrderBy`/mapping logic never actually ran.
- Adds new tests for previously entirely-untested code: `StationFlatFileService`/`StationComplexFlatFileService` (and transitively their CSV `DataMap`/attribute classes), `NypdPolicePrecinctService.GetFeatureCollection`, `CalculationService`'s null-guard, `AbstractShapeService`'s type-conversion/validation branches, `EnumHelper`/`GeoTransformationHelper`/`ReflectionExtensions` edge cases, `ShapeProfile`'s attribute readers, `IndividualLandmarkSiteShapeProfile.GetAlternativeName`, `BoundingBox`, and `ShapeConfiguration`.

Every class in `MicroService.Service.dll` is now at **100%** line coverage except `SubwayService` (75%). That gap is `SubwayService.FindPointsByRadius`, which is blocked by a pre-existing `Skip = "TODO FIX"` test (`FindPointsByRadius_ReturnsPointsWithinRadius`) — left untouched and documented here per explicit scope decision, rather than re-enabling/fixing a skipped test as part of this coverage pass.

## Validation

- [x] `make check`
- [x] `make build`
- [x] `make test`
- [x] `make analyze`

Validation results:

- `make check`: all pre-commit hooks pass (shellcheck, actionlint, gitleaks, codespell, cspell, markdownlint).
- `make build` / `make analyze`: solution builds with 0 warnings, 0 errors, full Roslyn analyzer gate enabled.
- `make test`: 273 passed, 0 failed, 12 skipped (all pre-existing skips, unchanged) — up from 251 passed before this change.
- Local `dotnet-coverage` + `reportgenerator` run confirms `MicroService.Service.dll` line coverage at 98.6%, with every class at 100% except `SubwayService` (75%, sole gap is the documented `FindPointsByRadius` skip).

## Dependency / Stack Info

- Base branch: master
- Stack dependencies: None
- Related PRs: None

## Known Risks

- None. Test-only change; no production code in `src/` was modified.

## Review Follow-Up

- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness

- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist