### PR TITLE
test: close FeatureServiceController coverage gap to 100%

### DIFF
--- a/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
+++ b/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
@@ -95,7 +95,19 @@ namespace MicroService.Test.Controllers
 
             // Assert
             Assert.IsType<OkObjectResult>(sut.Result);
-            loggerMock.Verify(l => l.IsEnabled(LogLevel.Information), Times.AtLeastOnce);
+
+            // CA1873 misreads this Moq verification expression as a real, eagerly-evaluated
+            // logger call; it's an expression tree matched against recorded invocations.
+#pragma warning disable CA1873
+            loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+#pragma warning restore CA1873
         }
 
         [Fact]
@@ -172,8 +184,9 @@ namespace MicroService.Test.Controllers
         {
             // Arrange
             var id = ShapeProperties.BoroughBoundaries;
+            DbaseFileHeader? nullDatabaseProperties = null;
             var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
-            shapeServiceMock.Setup(s => s.GetShapeDatabaseProperties()).Returns((DbaseFileHeader)null!);
+            shapeServiceMock.Setup(s => s.GetShapeDatabaseProperties()).Returns(nullDatabaseProperties!);
             shapeServiceMock.Setup(x => x.GetShapeProperties()).Returns(new ShapefileHeader
             {
                 Bounds = new Envelope(1, 2, 3, 4),
@@ -247,8 +260,9 @@ namespace MicroService.Test.Controllers
                 Y = 732036
             };
 
+            BoroughBoundaryShape? nullShape = null;
             var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
-            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum)).Returns((BoroughBoundaryShape?)null);
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum)).Returns(nullShape);
 
             var shapeServiceResolver = new Mock<ShapeServiceResolver>();
             shapeServiceResolver.Setup(r => r("BoroughBoundaries")).Returns(shapeServiceMock.Object);
@@ -278,8 +292,9 @@ namespace MicroService.Test.Controllers
             boroughServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum))
                 .Returns(new BoroughBoundaryShape { BoroCode = 1 });
 
+            CommunityDistrictShape? nullCommunityShape = null;
             var communityServiceMock = new Mock<IShapeService<CommunityDistrictShape>>();
-            communityServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum)).Returns((CommunityDistrictShape?)null);
+            communityServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum)).Returns(nullCommunityShape);
 
             var shapeServiceResolver = new Mock<ShapeServiceResolver>();
             shapeServiceResolver.Setup(r => r("BoroughBoundaries")).Returns(boroughServiceMock.Object);
@@ -481,8 +496,9 @@ namespace MicroService.Test.Controllers
                 Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 1) },
             };
 
+            IEnumerable<BoroughBoundaryShape>? nullResults = null;
             var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
-            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.Attributes)).Returns((IEnumerable<BoroughBoundaryShape>)null!);
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.Attributes)).Returns(nullResults!);
 
             var shapeServiceResolver = new Mock<ShapeServiceResolver>();
             shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
@@ -555,8 +571,9 @@ namespace MicroService.Test.Controllers
                 Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 999) },
             };
 
+            FeatureCollection? nullFeatureCollection = null;
             var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
-            shapeServiceMock.Setup(s => s.GetFeatureCollection(request.Attributes)).Returns((FeatureCollection?)null);
+            shapeServiceMock.Setup(s => s.GetFeatureCollection(request.Attributes)).Returns(nullFeatureCollection);
 
             var shapeServiceResolver = new Mock<ShapeServiceResolver>();
             shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);

--- a/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
+++ b/test/MicroService.Test/Controllers/FeatureServiceControllerTest.cs
@@ -8,6 +8,7 @@ using MicroService.WebApi.V1.Controllers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using System.Text;
@@ -49,12 +50,12 @@ namespace MicroService.Test.Controllers
             Assert.Equal(expectedResults, okResult.Value);
         }
 
-        [InlineData("InvalidKey")]
-        [Theory(Skip = "TODO: Resolve")]
-        public async Task GetFeatureList_WithInvalidRequest_ReturnsBadRequestResult(string key)
+        [Fact]
+        public async Task GetFeatureList_WithInvalidRequest_ReturnsBadRequestResult()
         {
-            // Arrange
-            var request = new FeatureAttributeRequestModel { Key = System.Enum.Parse<ShapeProperties>(key) };
+            // Arrange: an out-of-range enum value, since Enum.Parse throws for unparsable
+            // strings rather than returning an undefined value.
+            var request = new FeatureAttributeRequestModel { Key = (ShapeProperties)9999 };
 
             // Act
             var controller = GetFeatureServiceController();
@@ -78,6 +79,23 @@ namespace MicroService.Test.Controllers
             var shapesResult = Assert.IsType<IEnumerable<object>>(okResult.Value, exactMatch: false);
 
             Assert.All(shapesResult, Assert.NotNull);
+        }
+
+        [Fact]
+        public void Get_LogsResult_WhenInformationLoggingIsEnabled()
+        {
+            // Arrange
+            var loggerMock = new Mock<ILogger<FeatureServiceController>>();
+            loggerMock.Setup(l => l.IsEnabled(LogLevel.Information)).Returns(true);
+
+            var controller = new FeatureServiceController(new Mock<ShapeServiceResolver>().Object, loggerMock.Object);
+
+            // Act
+            var sut = controller.Get();
+
+            // Assert
+            Assert.IsType<OkObjectResult>(sut.Result);
+            loggerMock.Verify(l => l.IsEnabled(LogLevel.Information), Times.AtLeastOnce);
         }
 
         [Fact]
@@ -112,16 +130,78 @@ namespace MicroService.Test.Controllers
             Assert.IsType<OkObjectResult>(sut.Result);
         }
 
+        [Fact]
+        public void GetShapeProperties_ReturnsOkResult_WithFieldsListPopulated()
+        {
+            // Arrange
+            var id = ShapeProperties.BoroughBoundaries;
+            var databaseProperties = new DbaseFileHeader
+            {
+                NumRecords = 5,
+                Encoding = Encoding.UTF32,
+                LastUpdateDate = new DateTime(2022, 01, 01),
+            };
+            databaseProperties.AddColumn("BoroCode", 'N', 10, 0);
 
-        [InlineData("InvalidKey")]
-        [Theory(Skip = "TODO: Resolve")]
-        public void GetShapeProperties_ReturnsBadRequestResult(string key)
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetShapeDatabaseProperties()).Returns(databaseProperties);
+
+            shapeServiceMock.Setup(x => x.GetShapeProperties()).Returns(new ShapefileHeader
+            {
+                Bounds = new Envelope(1, 2, 3, 4),
+                ShapeType = ShapeGeometryType.Polygon,
+            });
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(id.ToString())).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var sut = controller.GetShapeProperties(id);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(sut.Result);
+            var fieldsListProperty = okResult.Value!.GetType().GetProperty("FieldsList")!;
+            var fieldsList = ((System.Collections.IEnumerable)fieldsListProperty.GetValue(okResult.Value)!).Cast<object>().ToList();
+            Assert.Single(fieldsList);
+        }
+
+        [Fact]
+        public void GetShapeProperties_ReturnsNotFoundResult_WhenDatabasePropertiesAreNull()
+        {
+            // Arrange
+            var id = ShapeProperties.BoroughBoundaries;
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetShapeDatabaseProperties()).Returns((DbaseFileHeader)null!);
+            shapeServiceMock.Setup(x => x.GetShapeProperties()).Returns(new ShapefileHeader
+            {
+                Bounds = new Envelope(1, 2, 3, 4),
+                ShapeType = ShapeGeometryType.Polygon,
+            });
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(id.ToString())).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var sut = controller.GetShapeProperties(id);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(sut.Result);
+        }
+
+
+        [Fact]
+        public void GetShapeProperties_ReturnsBadRequestResult()
         {
             //Arrange
             var controller = GetFeatureServiceController();
 
-            // Act
-            var sut = controller.GetShapeProperties(System.Enum.Parse<ShapeProperties>(key));
+            // Act: an out-of-range enum value, since Enum.Parse throws for unparsable
+            // strings rather than returning an undefined value.
+            var sut = controller.GetShapeProperties((ShapeProperties)9999);
 
             // Assert
             Assert.IsType<BadRequestResult>(sut.Result);
@@ -155,12 +235,73 @@ namespace MicroService.Test.Controllers
             Assert.Same(expected, okResult.Value);
         }
 
-        [Fact(Skip = "TODO: Fix")]
-        public async Task GetFeatureLookup_ReturnsBadRequestResult()
+        [Fact]
+        public async Task GetGeospatialLookup_ReturnsNoContent_WhenBoroughBoundariesLookupIsNull()
         {
+            // Arrange: the controller always validates against BoroughBoundaries first,
+            // regardless of the requested Type.
             var request = new FeatureGeoRequestModel
             {
-                //Type = null,
+                Type = ShapeProperties.BoroughBoundaries,
+                X = 1006187,
+                Y = 732036
+            };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum)).Returns((BoroughBoundaryShape?)null);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r("BoroughBoundaries")).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetGeospatialLookup(request);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetGeospatialLookup_ReturnsNotFound_WhenRequestedTypeLookupIsNull()
+        {
+            // Arrange: BoroughBoundaries validation succeeds, but the requested type
+            // (a different shape) has no match at the given coordinates.
+            var request = new FeatureGeoRequestModel
+            {
+                Type = ShapeProperties.CommunityDistricts,
+                X = -74.0064,
+                Y = 40.7142
+            };
+
+            var boroughServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            boroughServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum))
+                .Returns(new BoroughBoundaryShape { BoroCode = 1 });
+
+            var communityServiceMock = new Mock<IShapeService<CommunityDistrictShape>>();
+            communityServiceMock.Setup(s => s.GetFeatureLookup(request.X, request.Y, request.Datum)).Returns((CommunityDistrictShape?)null);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r("BoroughBoundaries")).Returns(boroughServiceMock.Object);
+            shapeServiceResolver.Setup(r => r("CommunityDistricts")).Returns(communityServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetGeospatialLookup(request);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetFeatureLookup_ReturnsBadRequestResult()
+        {
+            // Arrange: an out-of-range enum value; the default (unset) Type is 0,
+            // which is itself a defined ShapeProperties member and wouldn't trigger the guard.
+            var request = new FeatureGeoRequestModel
+            {
+                Type = (ShapeProperties)9999,
                 X = -74.0064,
                 Y = 40.7142
             };
@@ -187,6 +328,21 @@ namespace MicroService.Test.Controllers
 
             // Assert
             Assert.IsType<BadRequestObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithInvalidKey_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel { Key = "NotARealShapeKey", Attributes = null };
+
+            var controller = GetFeatureServiceController();
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            Assert.IsType<BadRequestResult>(result.Result);
         }
 
         [Fact]
@@ -217,6 +373,264 @@ namespace MicroService.Test.Controllers
 
             // Assert
             Assert.IsType<BadRequestObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetLookupFeatureGeoJson_WithInvalidKey_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel { Key = "NotARealShapeKey", Attributes = null };
+
+            var controller = GetFeatureServiceController();
+
+            // Act
+            var result = await controller.GetLookupFeatureGeoJson(request);
+
+            // Assert
+            Assert.IsType<BadRequestResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithInvalidAttributeKey_ReturnsBadRequestResult()
+        {
+            // Arrange: "NotARealAttribute" has no [FeatureName]/[MappingKey] on BoroughBoundaryShape.
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("NotARealAttribute", 1) },
+            };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+            Assert.Contains("NotARealAttribute", badRequest.Value!.ToString());
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithValidAttributes_ReturnsOkResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 1) },
+            };
+            var expected = new List<BoroughBoundaryShape> { new() { BoroCode = 1, BoroName = "Manhattan" } };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.Attributes)).Returns(expected);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var results = Assert.IsType<List<object>>(okResult.Value);
+            Assert.Single(results);
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithValidMappingKeyAttribute_ReturnsOkResult()
+        {
+            // Arrange: LPNumber is declared via [MappingKey] rather than [FeatureName],
+            // so this exercises the mappingFields branch of the field-validation union.
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "IndividualLandmarkHistoricDistricts",
+                Attributes = new List<KeyValuePair<string, object>> { new("LPNumber", "LP-00001") },
+            };
+            var expected = new List<IndividualLandmarkHistoricDistrictsShape> { new() { LPNumber = "LP-00001" } };
+
+            var shapeServiceMock = new Mock<IShapeService<IndividualLandmarkHistoricDistrictsShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.Attributes)).Returns(expected);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var results = Assert.IsType<List<object>>(okResult.Value);
+            Assert.Single(results);
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithNullLookupResult_ReturnsNotFoundResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 1) },
+            };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.Attributes)).Returns((IEnumerable<BoroughBoundaryShape>)null!);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetAttributeLookup_WithNoMatches_ReturnsNotFoundResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 999) },
+            };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureLookup(request.Attributes)).Returns(new List<BoroughBoundaryShape>());
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetAttributeLookup(request);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetLookupFeatureGeoJson_WithInvalidAttributeKey_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("NotARealAttribute", 1) },
+            };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetLookupFeatureGeoJson(request);
+
+            // Assert
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+            Assert.Contains("NotARealAttribute", badRequest.Value!.ToString());
+        }
+
+        [Fact]
+        public async Task GetLookupFeatureGeoJson_WithNoMatches_ReturnsNotFoundResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 999) },
+            };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureCollection(request.Attributes)).Returns((FeatureCollection?)null);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetLookupFeatureGeoJson(request);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetLookupFeatureGeoJson_WithValidAttributes_ReturnsOkResult()
+        {
+            // Arrange
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "BoroughBoundaries",
+                Attributes = new List<KeyValuePair<string, object>> { new("BoroCode", 1) },
+            };
+
+            var point = new Point(-74.0064, 40.7142);
+            var attributesTable = new AttributesTable(new Dictionary<string, object> { { "BoroCode", 1 } });
+            var featureCollection = new FeatureCollection { new Feature(point, attributesTable) };
+
+            var shapeServiceMock = new Mock<IShapeService<BoroughBoundaryShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureCollection(request.Attributes)).Returns(featureCollection);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetLookupFeatureGeoJson(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var resultCollection = Assert.IsType<FeatureCollection>(okResult.Value);
+            Assert.Single(resultCollection);
+        }
+
+        [Fact]
+        public async Task GetLookupFeatureGeoJson_WithValidMappingKeyAttribute_ReturnsOkResult()
+        {
+            // Arrange: LPNumber is declared via [MappingKey] rather than [FeatureName],
+            // so this exercises the mappingFields branch of the field-validation union.
+            var request = new FeatureAttributeLookupRequestModel
+            {
+                Key = "IndividualLandmarkHistoricDistricts",
+                Attributes = new List<KeyValuePair<string, object>> { new("LPNumber", "LP-00001") },
+            };
+
+            var point = new Point(-74.0064, 40.7142);
+            var attributesTable = new AttributesTable(new Dictionary<string, object> { { "LPNumber", "LP-00001" } });
+            var featureCollection = new FeatureCollection { new Feature(point, attributesTable) };
+
+            var shapeServiceMock = new Mock<IShapeService<IndividualLandmarkHistoricDistrictsShape>>();
+            shapeServiceMock.Setup(s => s.GetFeatureCollection(request.Attributes)).Returns(featureCollection);
+
+            var shapeServiceResolver = new Mock<ShapeServiceResolver>();
+            shapeServiceResolver.Setup(r => r(request.Key)).Returns(shapeServiceMock.Object);
+
+            var controller = GetFeatureServiceController(shapeServiceResolver.Object);
+
+            // Act
+            var result = await controller.GetLookupFeatureGeoJson(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var resultCollection = Assert.IsType<FeatureCollection>(okResult.Value);
+            Assert.Single(resultCollection);
         }
 
         private static FeatureServiceController GetFeatureServiceController(ShapeServiceResolver? resolver = null)


### PR DESCRIPTION
## Summary

- `FeatureServiceController` was the last controller still short on coverage (57.6%) after the previous WebApi controller-coverage pass (#503).
- Root-caused and fixed 3 pre-existing skipped tests (`Skip = "TODO: Resolve"` / `"TODO: Fix"`): each built its "invalid request" scenario via `Enum.Parse<ShapeProperties>("InvalidKey")`, but `Enum.Parse` throws on an unparsable string instead of returning an undefined enum value — so the test threw before the controller was ever called. Replaced with an out-of-range cast (e.g. `(ShapeProperties)9999`), which `Enum.IsDefined` correctly rejects, exercising the guard the tests were meant to test.
- Added new tests for the remaining untested branches:
  - `GetAttributeLookup` / `GetLookupFeatureGeoJson` happy paths, including the `[MappingKey]`-attribute validation branch (previously only the `[FeatureName]` branch was exercised, since the only shape used in tests — `BoroughBoundaryShape` — has no `[MappingKey]` properties; added a case using `IndividualLandmarkHistoricDistrictsShape.LPNumber`, which does).
  - `GetGeospatialLookup`'s `NoContent` (borough-boundaries validation lookup returns null) and `NotFound` (requested-type lookup returns null) branches.
  - `GetShapeProperties`'s `NotFound` branch and its `FieldsList` mapping lambda (needed an actually-enumerated, non-empty `Fields` collection — the existing OK test never populated or enumerated it).
  - `Get()`'s `Logger.IsEnabled(Information)` branch.

`FeatureServiceController` moves from 57.6% → **100%** line coverage.

## Validation

- [x] `make check`
- [x] `make build`
- [x] `make test`
- [x] `make analyze`

Validation results:

- `make check`: all pre-commit hooks pass.
- `make build` / `make analyze`: solution builds with 0 warnings, 0 errors (Roslyn + Roslynator gate).
- `make test`: 308 passed, 0 failed, 9 skipped (down from 12 — the 3 fixed tests are no longer skipped) — up from 289 passed before this change.
- Local `dotnet-coverage` + `reportgenerator` confirms `FeatureServiceController` at 100% and `MicroService.WebApi.dll` moving from 18.1% → 25.7%.

## Dependency / Stack Info

- Base branch: master
- Stack dependencies: None
- Related PRs: #503 (previous WebApi controller-coverage pass)

## Known Risks

- None. Test-only change; no production code in `src/` was modified.

## Review Follow-Up

- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness

- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist