### PR TITLE
ci: skip the 60s initial wait on manual auto-approve re-runs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -58,8 +58,13 @@ jobs:
               );
             };
 
-            core.info(`Waiting ${initialDelayMs / 1000}s before the first check — Copilot review consistently takes over a minute to appear`);
-            await new Promise(r => setTimeout(r, initialDelayMs));
+            const runAttempt = Number(process.env.GITHUB_RUN_ATTEMPT || '1');
+            if (runAttempt > 1) {
+              core.info(`Run attempt ${runAttempt} (manual re-run) — skipping the initial ${initialDelayMs / 1000}s wait, Copilot review has likely already posted`);
+            } else {
+              core.info(`Waiting ${initialDelayMs / 1000}s before the first check — Copilot review consistently takes over a minute to appear`);
+              await new Promise(r => setTimeout(r, initialDelayMs));
+            }
 
             for (let i = 0; i < maxAttempts; i++) {
               const { data: reviews } = await github.rest.pulls.listReviews({


### PR DESCRIPTION
## Summary

- When the "Auto Approve after Copilot Review" job is manually re-run from the Actions UI (e.g. after pushing a fix for Copilot review comments), `GITHUB_RUN_ATTEMPT` is `2` or higher. At that point Copilot's review has almost always already posted — you're re-running specifically because you know the review landed and want the approval to go through — so the unconditional 60s upfront sleep before the first poll is dead time with no benefit.
- Skips the 60s wait when `GITHUB_RUN_ATTEMPT > 1`, going straight to the existing 10s poll loop instead. First-attempt runs (fresh PR push) keep the original 60s wait, since Copilot review consistently takes over a minute to appear there.
- Uses `GITHUB_RUN_ATTEMPT`, a documented default GitHub Actions environment variable, rather than `context.runAttempt` (whose presence on the `actions/github-script` context object I couldn't verify offline).

## Validation

- [x] `make check`
- [ ] `make build` — not applicable, workflow-only change
- [ ] `make test` — not applicable, workflow-only change
- [ ] `make analyze` — not applicable, workflow-only change

Validation results:

- `make check`: all pre-commit hooks pass, including `actionlint` and YAML validation on the modified workflow file.
- Manually validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(...)"`.

## Dependency / Stack Info

- Base branch: master
- Stack dependencies: None
- Related PRs: None (this closes out a request made earlier in an unrelated session that was deferred at the time)

## Known Risks

- None. This only changes CI workflow timing behavior; the actual Copilot-review-detection and inline-comment-blocking logic is untouched.

## Review Follow-Up

- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness

- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist