### PR TITLE
ci: wire up Codecov coverage upload in the Test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,4 +121,11 @@ jobs:
             > 'files/LPC_Individual_Landmark_and_Historic_Building_Database/LPC_Individual_Landmark_and_Historic_District_Building_Database_20231209.dbf'
 
       - name: Test solution
-        run: dotnet test MicroService.sln --configuration Release
+        run: dotnet test MicroService.sln --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary

- The README's Codecov badge (`codecov.io/gh/stuartshay/MicroService`) has been dead — no workflow in this repo has ever generated or uploaded a coverage report to Codecov, so the badge has silently shown stale/no data.
- Adds `--collect:"XPlat Code Coverage"` to the existing `dotnet test` invocation in `ci.yml`'s `test` job. `coverlet.collector` is already a test project dependency, so this produces a Cobertura-format report with no new package installs.
- Uploads the report via `codecov/codecov-action@v5`, using the existing `CODECOV_TOKEN` repo secret (set back in 2023 — may need to be regenerated on Codecov's side if it's since been rotated/expired; that's a follow-up outside this PR).
- Runs on every `test` job execution — both PRs and pushes to master — so Codecov can post PR coverage-diff comments in addition to keeping the master badge current.
- `fail_ci_if_error: false`, so if the token turns out to be stale, the upload step fails soft instead of turning into a blocking required-check failure on every PR.

## Validation

- [x] `make check`
- [ ] `make build` — not applicable, CI-workflow-only change
- [x] `make test` (verified the underlying `dotnet test --collect` invocation locally)
- [ ] `make analyze` — not applicable, CI-workflow-only change

Validation results:

- `make check`: all pre-commit hooks pass (YAML validation, actionlint).
- Ran `dotnet test test/MicroService.Test/MicroService.Test.csproj --configuration Release --collect:"XPlat Code Coverage" --results-directory /tmp/coverage-test` locally: 308 passed, 0 failed, produced a valid `coverage.cobertura.xml` (`line-rate="0.6966"`, real line/branch counts).
- Cannot fully validate the Codecov upload itself from this environment (requires the actual GitHub Actions run against the live `CODECOV_TOKEN` secret) — first real signal will be on this PR's own CI run.

## Dependency / Stack Info

- Base branch: master
- Stack dependencies: None
- Related PRs: None

## Known Risks

- If `CODECOV_TOKEN` is stale/expired, the upload will silently fail (by design, via `fail_ci_if_error: false`) and the badge will keep showing no data until the token is regenerated and updated in repo secrets.

## Review Follow-Up

- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness

- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist