### PR TITLE
test: cover health checks and Swagger document filter

### DIFF
--- a/src/MicroService.WebApi/MicroService.WebApi.csproj
+++ b/src/MicroService.WebApi/MicroService.WebApi.csproj
@@ -14,6 +14,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="MicroService.Test" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="CronExpressionDescriptor" Version="2.51.0" />
 		<PackageReference Include="Cronos" Version="0.13.0" />
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />

--- a/test/MicroService.Test/Unit/CronJobServiceHealthCheckTest.cs
+++ b/test/MicroService.Test/Unit/CronJobServiceHealthCheckTest.cs
@@ -1,0 +1,29 @@
+using MicroService.WebApi.Services;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class CronJobServiceHealthCheckTest
+    {
+        [Fact]
+        public async Task CheckHealthAsync_ReturnsHealthy_WhenStartupTaskCompleted()
+        {
+            var healthCheck = new CronJobServiceHealthCheck { StartupTaskCompleted = true };
+
+            var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_ReturnsUnhealthy_WhenStartupTaskNotCompleted()
+        {
+            var healthCheck = new CronJobServiceHealthCheck { StartupTaskCompleted = false };
+
+            var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+    }
+}

--- a/test/MicroService.Test/Unit/FolderHealthCheckTest.cs
+++ b/test/MicroService.Test/Unit/FolderHealthCheckTest.cs
@@ -33,7 +33,7 @@ namespace MicroService.Test.Unit
         [Fact]
         public async Task CheckHealthAsync_ReturnsUnhealthy_WhenFolderDoesNotExist()
         {
-            var missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var missingPath = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var healthCheck = new FolderHealthCheck(missingPath);
 
             var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);

--- a/test/MicroService.Test/Unit/FolderHealthCheckTest.cs
+++ b/test/MicroService.Test/Unit/FolderHealthCheckTest.cs
@@ -1,0 +1,44 @@
+using MicroService.WebApi.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class FolderHealthCheckTest
+    {
+        [Fact]
+        public void AddFolderHealthCheck_RegistersHealthCheck()
+        {
+            var services = new ServiceCollection();
+
+            services.AddHealthChecks().AddFolderHealthCheck(Path.GetTempPath(), name: "test-folder");
+
+            using var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<HealthCheckServiceOptions>>().Value;
+
+            Assert.Contains(options.Registrations, r => r.Name == "test-folder");
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_ReturnsHealthy_WhenFolderExists()
+        {
+            var healthCheck = new FolderHealthCheck(Path.GetTempPath());
+
+            var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_ReturnsUnhealthy_WhenFolderDoesNotExist()
+        {
+            var missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var healthCheck = new FolderHealthCheck(missingPath);
+
+            var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+    }
+}

--- a/test/MicroService.Test/Unit/SwaggerDocumentFilterTest.cs
+++ b/test/MicroService.Test/Unit/SwaggerDocumentFilterTest.cs
@@ -1,0 +1,28 @@
+using MicroService.WebApi.Extensions.Swagger;
+using Microsoft.OpenApi;
+using Xunit;
+
+namespace MicroService.Test.Unit
+{
+    public class SwaggerDocumentFilterTest
+    {
+        [Fact]
+        public void Apply_AddsRoutingApiTag()
+        {
+            var filter = new SwaggerDocumentFilter();
+            var document = new OpenApiDocument();
+
+            filter.Apply(document, null!);
+
+            Assert.Contains(document.Tags!, t => t.Name == "RoutingApi");
+        }
+
+        [Fact]
+        public void Apply_ThrowsArgumentNullException_WhenDocumentIsNull()
+        {
+            var filter = new SwaggerDocumentFilter();
+
+            Assert.Throws<ArgumentNullException>(() => filter.Apply(null!, null!));
+        }
+    }
+}

--- a/test/MicroService.Test/Unit/SwaggerDocumentFilterTest.cs
+++ b/test/MicroService.Test/Unit/SwaggerDocumentFilterTest.cs
@@ -1,5 +1,8 @@
 using MicroService.WebApi.Extensions.Swagger;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi;
+using Moq;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
 namespace MicroService.Test.Unit
@@ -12,7 +15,7 @@ namespace MicroService.Test.Unit
             var filter = new SwaggerDocumentFilter();
             var document = new OpenApiDocument();
 
-            filter.Apply(document, null!);
+            filter.Apply(document, CreateContext());
 
             Assert.Contains(document.Tags!, t => t.Name == "RoutingApi");
         }
@@ -22,7 +25,12 @@ namespace MicroService.Test.Unit
         {
             var filter = new SwaggerDocumentFilter();
 
-            Assert.Throws<ArgumentNullException>(() => filter.Apply(null!, null!));
+            Assert.Throws<ArgumentNullException>(() => filter.Apply(null!, CreateContext()));
         }
+
+        private static DocumentFilterContext CreateContext() => new(
+            new List<ApiDescription>(),
+            Moq.Mock.Of<ISchemaGenerator>(),
+            new SchemaRepository());
     }
 }


### PR DESCRIPTION
## Summary

- Adds unit tests for three previously 0%-covered `MicroService.WebApi.dll` classes: `CronJobServiceHealthCheck`, `FolderHealthCheck` (plus its `AddFolderHealthCheck` registration extension), and `SwaggerDocumentFilter`. All three are small, self-contained, and needed no real infrastructure (no DB, no HTTP server, no file-system watchers).
- `CronJobServiceHealthCheck` is `internal`, so this adds `InternalsVisibleTo("MicroService.Test")` to `MicroService.WebApi.csproj` — the same pattern already implicitly relied on for public controller classes, just extended to internals.

Deliberately left uncovered (documented, not silently skipped):
- `ConfigureSwaggerOptions` — needs a real `IApiVersionDescriptionProvider`/`ApiVersionDescription`, which requires standing up the full ASP.NET Core API-versioning pipeline rather than a simple mock.
- The Swagger example providers (`GetShapePropertiesExample`, `GetShapeTypesExample`, `SwaggerFeatureRequestExamples`) — pure example-data generators with no branching logic worth testing in isolation.
- `CronJobService` / `InMemoryCacheShapefileCronJobService` — real background timers and `FileSystemWatcher` usage; meaningfully testing these needs `WebApplicationFactory`-style integration tests, not unit tests.
- `Program.cs` — app startup/DI wiring, same category.

`MicroService.WebApi.dll` moves from 25.7% → 29.9%. Overall solution coverage moves from 84.9% → 85.7% (now visible live on the Codecov badge after #507).

## Validation

- [x] `make check`
- [x] `make build`
- [x] `make test`
- [x] `make analyze`

Validation results:

- `make check`: all pre-commit hooks pass.
- `make build` / `make analyze`: solution builds with 0 warnings, 0 errors (Roslyn + Roslynator gate).
- `make test`: 315 passed, 0 failed, 9 skipped (all pre-existing, unchanged) — up from 308 passed before this change.
- Local `dotnet-coverage` + `reportgenerator` confirms `FolderHealthCheck`, `SwaggerDocumentFilter`, `SystemHealthCheckBuilderExtensions`, and `CronJobServiceHealthCheck` all at 100%.

## Dependency / Stack Info

- Base branch: master
- Stack dependencies: None
- Related PRs: #503, #505 (previous WebApi controller-coverage passes), #507 (Codecov upload wiring)

## Known Risks

- `InternalsVisibleTo` slightly widens what `MicroService.Test` can reach into `MicroService.WebApi` — standard, low-risk pattern for unit-testing internal types, and doesn't change what ships in the production assembly.

## Review Follow-Up

- [ ] GitHub Copilot review completed on the current head SHA
- [ ] Actionable review comments addressed and replied to with commit SHA and validation evidence
- [ ] Required review threads resolved
- [ ] No newer commit or rebase invalidated completed review or CI results

## Merge Readiness

- [ ] PR is ready for review and conflict-free
- [ ] Required lint, build, and test checks pass on the current head SHA
- [ ] Required code scanning checks pass on the current head SHA
- [ ] For a stack, every layer satisfies the same checklist